### PR TITLE
feat: column type inference (INTEGER, REAL, TEXT) for correct numeric queries

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -39,14 +39,33 @@ pub fn build(b: *std.Build) void {
     const run_step = b.step("run", "Run the app");
     run_step.dependOn(&run_cmd.step);
 
-    // Integration test: pipe a small CSV and check the output
-    const test_cmd = b.addSystemCommand(&.{
-        "sh", "-c",
-        \\printf 'name,age\nAlice,30\nBob,25\nCarol,35' | ./zig-out/bin/sql-pipe 'SELECT name FROM t WHERE CAST(age AS INT) > 27' | diff - <(printf 'Alice\nCarol\n')
+    // Integration test 1: type inference — numeric comparisons work without CAST
+    const test_infer = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\printf 'name,age\nAlice,30\nBob,25\nCarol,35' | ./zig-out/bin/sql-pipe 'SELECT name FROM t WHERE age > 27' | diff - <(printf 'Alice\nCarol\n')
     });
-    test_cmd.step.dependOn(b.getInstallStep());
+    test_infer.step.dependOn(b.getInstallStep());
+
+    // Integration test 2: --no-type-inference preserves legacy TEXT behavior
+    // With TEXT comparison: "9" > "2" is true, but "10" > "2" is false (string: "1" < "2")
+    // So only Alice is returned, proving string comparison is used
+    const test_no_infer = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\printf 'name,val\nAlice,9\nBob,10\n' | ./zig-out/bin/sql-pipe --no-type-inference 'SELECT name FROM t WHERE val > 2 ORDER BY name' | diff - <(printf 'Alice\n')
+    });
+    test_no_infer.step.dependOn(b.getInstallStep());
+
+    // Integration test 3: max/min on REAL columns return numeric results
+    const test_real = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\printf 'item,price\nA,9.99\nB,3.00\nC,12.50\n' | ./zig-out/bin/sql-pipe 'SELECT max(price), min(price) FROM t' | diff - <(printf '12.5,3.0\n')
+    });
+    test_real.step.dependOn(b.getInstallStep());
+
     const test_step = b.step("test", "Run integration tests");
-    test_step.dependOn(&test_cmd.step);
+    test_step.dependOn(&test_infer.step);
+    test_step.dependOn(&test_no_infer.step);
+    test_step.dependOn(&test_real.step);
 
     // Unit tests for the RFC 4180 CSV parser (src/csv.zig)
     const unit_tests = b.addTest(.{

--- a/src/main.zig
+++ b/src/main.zig
@@ -5,8 +5,11 @@ const c = @cImport({
 const csv = @import("csv.zig");
 
 // SQLITE_STATIC (null): SQLite assumes the memory is constant and won't free it.
-// Safe because sqlite3_step is called immediately after binding, before the row
-// buffer is freed.
+// Safety: sqlite3_step is called inside insertRowTyped immediately after all
+// bindings, returning SQLITE_DONE before the function returns. The caller's
+// row buffer is only freed after insertRowTyped returns, so the bound pointers
+// remain valid throughout the statement's execution. sqlite3_reset at the top
+// of the next call releases any prior references.
 const SQLITE_STATIC: c.sqlite3_destructor_type = null;
 
 // ─── Error types ─────────────────────────────────────────────────────────────
@@ -354,7 +357,8 @@ fn insertRowTyped(
 
         if (val.len == 0) {
             // Empty / NULL value → bind as SQL NULL regardless of column type
-            _ = c.sqlite3_bind_null(stmt, col_idx);
+            if (c.sqlite3_bind_null(stmt, col_idx) != c.SQLITE_OK)
+                return error.BindFailed;
         } else switch (col_type) {
             .INTEGER => {
                 if (std.fmt.parseInt(i64, val, 10)) |n| {
@@ -386,7 +390,8 @@ fn insertRowTyped(
     // Bind NULL for any trailing columns the row is short of
     // Loop invariant: params 1..col_idx-1 are bound; col_idx..param_count become NULL
     while (col_idx <= param_count) : (col_idx += 1) {
-        _ = c.sqlite3_bind_null(stmt, col_idx);
+        if (c.sqlite3_bind_null(stmt, col_idx) != c.SQLITE_OK)
+            return error.BindFailed;
     }
 
     if (c.sqlite3_step(stmt) != c.SQLITE_DONE) return error.StepFailed;


### PR DESCRIPTION
## Summary

Closes #4

SQLite stored all values as `TEXT` via `sqlite3_bind_text`, causing numeric comparisons like `WHERE age > 30` to silently fail (`'30' > '9'` is false in string ordering). This PR implements buffer-first single-pass column type inference so the tool behaves correctly for numeric data without requiring explicit casts.

## Approach — buffer-first, single-pass

1. Read the first **N** rows (default: 100) into an in-memory buffer while scanning to infer column types.
2. Once types are determined (or N rows exhausted), create the table with inferred SQL types.
3. Insert buffered rows first, then continue reading from stdin and inserting directly — no second pass, no seeking stdin.

## Changes

| Component | What changed |
|---|---|
| `ColumnType` enum | `TEXT`, `INTEGER`, `REAL` + `INFERENCE_BUFFER_SIZE = 100` |
| `isInteger` / `isReal` | Pattern helpers for per-value classification |
| `inferTypes` | Scans buffered rows; ignores empty/NULL; defaults to `TEXT` when column has no data |
| `createTable` | Accepts `[]const ColumnType`; emits correct SQLite affinity per column |
| `insertRowTyped` | Uses `sqlite3_bind_int64` / `_double` / `_text`; empty fields → `NULL` |
| `ParsedArgs` + `parseArgs` | Returns struct with `.query` and `.type_inference`; parses `--no-type-inference` |
| `main` | Buffer ≤100 rows → infer types → create table → insert buffer → stream rest |

## Acceptance Criteria

- [x] Integer columns (all values match `[+-]?[0-9]+`) bound as `sqlite3_bind_int64`
- [x] Float columns bound as `sqlite3_bind_double`
- [x] NULL/empty values do not prevent a column from being inferred as numeric
- [x] Columns with mixed types fall back to TEXT
- [x] `SELECT max(price), min(price) FROM t` returns correct numeric results
- [x] Type inference performed on first **N** rows (100) stored in a memory buffer
- [x] Remaining rows streamed and inserted directly after buffer consumed
- [x] `--no-type-inference` flag allows opting out (pure TEXT mode, no buffering)