### PR TITLE
feat: release workflow on tag push with create-or-upload logic

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*.*.*"
 
 env:
   SQLITE_VERSION: "3490100"
@@ -125,10 +126,20 @@ jobs:
         working-directory: artifacts
         run: sha256sum * | tee sha256sums.txt
 
-      - name: Upload assets to release
+      - name: Create or update GitHub Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${{ github.ref_name }}" artifacts/* \
-            --repo "${{ github.repository }}" \
-            --clobber
+          if gh release view "${{ github.ref_name }}" --repo "${{ github.repository }}" > /dev/null 2>&1; then
+            gh release edit "${{ github.ref_name }}" --draft=false \
+              --repo "${{ github.repository }}"
+            gh release upload "${{ github.ref_name }}" artifacts/* \
+              --repo "${{ github.repository }}" \
+              --clobber
+          else
+            gh release create "${{ github.ref_name }}" \
+              --title "${{ github.ref_name }}" \
+              --generate-notes \
+              --repo "${{ github.repository }}" \
+              artifacts/*
+          fi


### PR DESCRIPTION
Closes #5

## Changes

- **Trigger**: changed from `release: published` to `push: tags: v*.*.*` so the workflow fires automatically when a version tag is pushed — no manual release publishing required.
- **Release job**: replaced the bare `gh release upload` (which would fail if no release exists yet) with create-or-update logic:
  - If Release Drafter has already drafted a release for this tag → publish it (`--draft=false`) and upload all assets.
  - Otherwise → create a new release with `--generate-notes` and upload assets in one step.
- SHA256 checksums (`sha256sums.txt`) are still generated and included as an asset.
- `.github/release-drafter.yml` and its trigger workflow were already present from prior work.

## Acceptance Criteria

- [x] CI workflow triggers on `push` to tags matching `v*.*.*`
- [x] Builds static binaries for `x86_64-linux-musl`, `x86_64-macos`, `aarch64-macos`, `x86_64-windows` (and many more)
- [x] All binaries are attached to the GitHub Release as assets
- [x] Each asset is named `sql-pipe-<target>` (or `.exe` for Windows)
- [x] SHA256 checksums file is also attached
- [x] Release notes are auto-generated from merged PRs (Release Drafter + `--generate-notes` fallback)