### PR TITLE
ci: add Zig cache and build.zig integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,15 @@ jobs:
         with:
           version: ${{ env.ZIG_VERSION }}
 
+      - name: Cache Zig
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/zig
+            ~/AppData/Local/zig
+          key: zig-cache-${{ matrix.os }}-${{ hashFiles('build.zig', 'build.zig.zon') }}
+          restore-keys: zig-cache-${{ matrix.os }}-
+
       - name: Download SQLite amalgamation
         shell: bash
         run: |
@@ -50,6 +59,10 @@ jobs:
 
       - name: Unit tests (csv.zig)
         run: zig build unit-test
+
+      - name: Integration tests (build.zig)
+        if: runner.os != 'Windows'
+        run: zig build test
 
       - name: Integration test (Unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
## Summary

Enhances the CI workflow to satisfy all acceptance criteria from #8.

## Changes

- **Zig build cache**: caches `~/.cache/zig` (Linux/macOS) and `~/AppData/Local/zig` (Windows) using `actions/cache@v4`, keyed on OS and `build.zig`/`build.zig.zon` hashes
- **`zig build test`**: runs the integration tests defined in `build.zig` (type inference, `--no-type-inference`, REAL aggregates) on Unix platforms

## Acceptance Criteria checklist

- [x] Runs on every push and pull request to `master`/`main`
- [x] Builds with `zig build` (ReleaseSafe)
- [x] Runs all tests with `zig build test`
- [x] At least one integration test: pipe CSV via stdin and assert SQL output
- [x] Matrix build covers: `ubuntu-latest`, `macos-latest`, `windows-latest`
- [x] Build status badge added to README

Closes #8