### PR TITLE
feat: Add man page and update release workflow (#22)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,11 @@ jobs:
         with:
           version: ${{ env.ZIG_VERSION }}
 
+      - name: Install scdoc (to generate man page)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y scdoc
+
       - name: Download SQLite amalgamation
         run: |
           mkdir -p lib
@@ -88,16 +93,23 @@ jobs:
             -Dtarget=${{ matrix.target }} \
             -Doptimize=ReleaseSafe
 
+      - name: Generate man page
+        run: zig build man
+
       - name: Stage artifact
         run: |
           mkdir -p dist
           cp zig-out/bin/sql-pipe${{ matrix.ext }} dist/${{ matrix.asset }}${{ matrix.ext }}
+          # Include man page (generated the same way for all targets)
+          if [ -f zig-out/share/man/man1/sql-pipe.1.gz ]; then
+            cp zig-out/share/man/man1/sql-pipe.1.gz dist/sql-pipe.1.gz
+          fi
 
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.asset }}
-          path: dist/${{ matrix.asset }}${{ matrix.ext }}
+          path: dist/
           if-no-files-found: error
 
   release:

--- a/build.zig
+++ b/build.zig
@@ -38,6 +38,24 @@ pub fn build(b: *std.Build) void {
 
     b.installArtifact(exe);
 
+    // Generate man page from scdoc source if scdoc (and gzip) are available (optional dependencies)
+    const man_step = b.step("man", "Generate man page with scdoc (optional)");
+
+    // Portable alternative: use a simple shell command that checks for scdoc/gzip availability
+    // The build step itself is lightweight and depends only on bash (standard on CI/Unix systems)
+    const build_man = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\if command -v scdoc >/dev/null 2>&1 && command -v gzip >/dev/null 2>&1; then
+        \\  mkdir -p zig-out/share/man/man1
+        \\  scdoc < docs/sql-pipe.1.scd | gzip -c > zig-out/share/man/man1/sql-pipe.1.gz
+        \\  echo "✓ Generated man page: zig-out/share/man/man1/sql-pipe.1.gz"
+        \\else
+        \\  echo "⚠ scdoc and/or gzip not found. Install them to generate man page."
+        \\  echo "  Manual source: docs/sql-pipe.1.scd"
+        \\fi
+    });
+    man_step.dependOn(&build_man.step);
+
     const run_cmd = b.addRunArtifact(exe);
     run_cmd.step.dependOn(b.getInstallStep());
     if (b.args) |args| {

--- a/docs/sql-pipe.1.scd
+++ b/docs/sql-pipe.1.scd
@@ -1,0 +1,83 @@
+sql-pipe(1)
+
+NAME
+	sql-pipe - Execute SQL queries on CSV data from stdin
+
+SYNOPSIS
+	*sql-pipe* [OPTIONS] <query>
+
+DESCRIPTION
+	sql-pipe reads CSV data from standard input, loads it into an in-memory SQLite
+	database table named *t*, executes the provided SQL query, and prints the results
+	as CSV to standard output.
+
+	This tool is useful for quick data transformations, filtering, grouping, and
+	aggregations on CSV files without manual SQL database setup.
+
+	All input columns are automatically loaded into the table with names derived from
+	the CSV header row. By default, column types (TEXT, INTEGER, REAL) are inferred
+	from the first 100 rows of data. Use *--no-type-inference* to disable this
+	behavior and treat all columns as TEXT.
+
+	Exit codes follow a structured convention for scripting integration (see EXIT CODES
+	section).
+
+OPTIONS
+	*--no-type-inference*
+		Treat all columns as TEXT. Skips automatic type detection and uses plain
+		TEXT affinity for all columns in the SQLite table. This can improve
+		performance on very large datasets if type inference is not needed.
+
+	*-h, --help*
+		Print the help message and exit with code 0.
+
+	*-V, --version*
+		Print the version number and exit with code 0.
+
+EXAMPLES
+	Select all rows. Use a comma-separated list of columns or asterisk for all:
+
+		$ cat <<'EOF' | sql-pipe 'SELECT name, age FROM t'
+		name,age
+		Alice,30
+		Bob,25
+		EOF
+		name,age
+		Alice,30
+		Bob,25
+
+	Group data by region and sum revenue:
+
+		$ cat sales.csv | sql-pipe 'SELECT region, SUM(revenue) FROM t GROUP BY region'
+
+	Filter rows where age is greater than 25:
+
+		$ sql-pipe 'SELECT name FROM t WHERE age > 25' < data.csv
+
+	Process data with type inference disabled:
+
+		$ cat numbers.csv | sql-pipe --no-type-inference 'SELECT name, id FROM t WHERE id = "001"'
+
+EXIT CODES
+	*0*
+		Success: query executed successfully and results were output.
+
+	*1*
+		Usage error: missing query argument, unrecognized flag, or argument parsing
+		failure.
+
+	*2*
+		CSV parse error: malformed CSV input (e.g., mismatched quotes, incomplete
+		fields).
+
+	*3*
+		SQL error: query execution failed in SQLite (e.g., invalid SQL syntax,
+		type mismatch, or missing table).
+
+AUTHORS
+	Victor Varela <https://github.com/vmvarela>
+
+SEE ALSO
+	*sqlite3*(1), *csv*(5)
+
+	For more information, visit https://github.com/vmvarela/sql-pipe


### PR DESCRIPTION
## Description

Implements a Unix manual page for `sql-pipe` using scdoc format and integrates it into the release workflow.

## Acceptance Criteria - Completed

- [x] `docs/sql-pipe.1.scd` written in scdoc format covering: NAME, SYNOPSIS, DESCRIPTION, OPTIONS, EXAMPLES, EXIT CODES, AUTHORS, SEE ALSO
- [x] `build.zig` adds `zig build man` step that generates `sql-pipe.1.gz` when `scdoc` is available (optional dependency)
- [x] Man page is included in the release workflow (added to release artifacts)
- [x] Man page is consistent with `--help` output
- [x] Documentation includes all options and exit codes

## Implementation Details

### Files Created
- **`docs/sql-pipe.1.scd`**: scdoc formatted man page with complete documentation

### Files Modified
- **`build.zig`**: Added optional build step `zig build man` that generates `sql-pipe.1.gz` using scdoc
- **`.github/workflows/release.yml`**: 
  - Installs scdoc in build environment
  - Executes `zig build man` during release builds
  - Includes `sql-pipe.1.gz` in release artifacts

## Testing

The man page can be generated locally with:
```sh
zig build man
```

Once installed (via Homebrew/AUR or manually to `/usr/share/man/man1/`), it can be viewed with:
```sh
man sql-pipe
```

## Notes

- scdoc is an optional dependency - builds continue normally if it's not installed
- Both scdoc and gzip are standard Unix utilities (always available in release CI)
- The man page provides the same information as `--help` with more detail and Unix conventions

Closes #22"