### PR TITLE
feat: Add Homebrew tap (vmvarela/homebrew-sql-pipe)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,14 @@ $ curl -s https://example.com/data.csv | sql-pipe 'SELECT region, SUM(revenue) F
 
 ## Quick Start
 
-Pre-built binaries for Linux, macOS (Intel + Apple Silicon), and Windows are on the [Releases page](https://github.com/vmvarela/sql-pipe/releases).
+**macOS / Linux via Homebrew:**
+
+```sh
+brew tap vmvarela/sql-pipe
+brew install sql-pipe
+```
+
+**Pre-built binaries** for Linux, macOS (Intel + Apple Silicon), and Windows are also available on the [Releases page](https://github.com/vmvarela/sql-pipe/releases).
 
 To build from source (requires [Zig 0.15+](https://ziglang.org/download/)):
 


### PR DESCRIPTION
## Summary

Creates the Homebrew tap `vmvarela/homebrew-sql-pipe` and documents the brew installation method.

## Changes

- **[vmvarela/homebrew-sql-pipe](https://github.com/vmvarela/homebrew-sql-pipe)** — new repository with:
  - `Formula/sql-pipe.rb`: handles `aarch64-macos`, `x86_64-macos`, and `x86_64-linux` via `on_macos`/`on_linux` blocks; SHA256 checksums from `sha256sums.txt` of v0.1.0
  - `README.md`: documents the tap and supported platforms
- **README.md** (this repo): adds `brew tap vmvarela/sql-pipe && brew install sql-pipe` as the first installation method in Quick Start

## How to install

```sh
brew tap vmvarela/sql-pipe
brew install sql-pipe
```

Closes #20