### PR TITLE
chore: remove dead sed strip from update-homebrew CI job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -212,9 +212,6 @@ jobs:
           end
           FORMULA
 
-          # Strip leading whitespace from heredoc (was indented for readability)
-          sed -i 's/^          //' sql-pipe.rb
-
           # Substitute placeholders with actual values
           sed -i "s/__VERSION__/${VERSION}/g"               sql-pipe.rb
           sed -i "s/__SHA_MACOS_ARM64__/${SHA_MACOS_ARM64}/g" sql-pipe.rb


### PR DESCRIPTION
## Summary

Closes #59

Removes the dead `sed -i 's/^          //' sql-pipe.rb` from the `update-homebrew` job. The heredoc uses a quoted delimiter (`<<'FORMULA'`), so the sed pattern never matched anything — identical to the no-op removed from AUR (PR #58), Nix, and Scoop (PR #56).

## Definition of Done

- [x] Dead `sed` line and comment removed
- [x] `zig build test` + `ziglint` pass
- [x] Self-reviewed