### PR TITLE
chore(nix): update versions.json to v0.3.0

### DIFF
--- a/packaging/nix/versions.json
+++ b/packaging/nix/versions.json
@@ -1,22 +1,22 @@
 {
   "x86_64-linux": {
-    "url": "https://github.com/vmvarela/sql-pipe/releases/download/v0.2.0/sql-pipe-x86_64-linux",
-    "sha256": "f3a3235e33aba0aa0c42741c0aa207738405a40ee88a52985d4280059c4989ff",
-    "version": "0.2.0"
+    "url": "https://github.com/vmvarela/sql-pipe/releases/download/v0.3.0/sql-pipe-x86_64-linux",
+    "sha256": "f2d8619561f0b0f946f1ef51d899eebf239548d5a2d88b70fffbd13d437175db",
+    "version": "0.3.0"
   },
   "aarch64-linux": {
-    "url": "https://github.com/vmvarela/sql-pipe/releases/download/v0.2.0/sql-pipe-aarch64-linux",
-    "sha256": "f4acf74d56cf7f882c6eca1507ad2d30ff07ee81715b6d33f1c43ba074c42a96",
-    "version": "0.2.0"
+    "url": "https://github.com/vmvarela/sql-pipe/releases/download/v0.3.0/sql-pipe-aarch64-linux",
+    "sha256": "c66c8743b00799d03eac462cb0c5d51c16e6c330bd8a3c8ebd20828a563ac541",
+    "version": "0.3.0"
   },
   "x86_64-darwin": {
-    "url": "https://github.com/vmvarela/sql-pipe/releases/download/v0.2.0/sql-pipe-x86_64-macos",
-    "sha256": "09d407faa63ff291c1e72e64f379ffcd1fa684f366a94dc513001a35dfe5449c",
-    "version": "0.2.0"
+    "url": "https://github.com/vmvarela/sql-pipe/releases/download/v0.3.0/sql-pipe-x86_64-macos",
+    "sha256": "9b95accb1256ce3e2d2da836a425ff57d6aae967e16488d152c089ae86c2883d",
+    "version": "0.3.0"
   },
   "aarch64-darwin": {
-    "url": "https://github.com/vmvarela/sql-pipe/releases/download/v0.2.0/sql-pipe-aarch64-macos",
-    "sha256": "f5f8c6357c74e67b3ef73d09fbd33cf30a0e6e12ef2d66e8abeaa89afb1a0ab8",
-    "version": "0.2.0"
+    "url": "https://github.com/vmvarela/sql-pipe/releases/download/v0.3.0/sql-pipe-aarch64-macos",
+    "sha256": "24f0f09aa20430c3fc5d5e0b2d6da15c098df5e70577f68bc62052c7dc56f660",
+    "version": "0.3.0"
   }
 }


### PR DESCRIPTION
## Summary

- Manual update of `packaging/nix/versions.json` to v0.3.0 with SHA256 hashes from the release checksums file
- The CI `update-nix` job failed because it tries to push directly to `master`, which is blocked by branch protection rules (see #63)
- All hashes verified against `sha256sums.txt` from the v0.3.0 release

Closes the immediate gap — #63 tracks the CI fix to prevent this from recurring.