### PR TITLE
docs: add --json flag and Alpine APK install to README and man page

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,15 @@ sudo rpm -i https://github.com/vmvarela/sql-pipe/releases/latest/download/sql-pi
 
 Replace `VERSION` with the release version (e.g. `0.2.0`) and `x86_64` with your architecture (`aarch64`).
 
+**Alpine Linux (.apk package):**
+
+```sh
+wget https://github.com/vmvarela/sql-pipe/releases/latest/download/sql-pipe_VERSION_x86_64.apk
+sudo apk add --allow-untrusted sql-pipe_VERSION_x86_64.apk
+```
+
+Replace `VERSION` with the release version (e.g. `0.2.0`) and `x86_64` with your architecture (`aarch64`).
+
 **Arch Linux (AUR):** install with your preferred AUR helper:
 
 ```sh
@@ -138,6 +147,15 @@ $ cat data.tsv | sql-pipe --tsv 'SELECT * FROM t'
 $ cat data.tsv | sql-pipe --delimiter '\t' 'SELECT * FROM t'
 ```
 
+Output results as a JSON array of objects with `--json`:
+
+```sh
+$ printf 'name,age\nAlice,30\nBob,25' | sql-pipe --json 'SELECT * FROM t'
+[{"name":"Alice","age":30},{"name":"Bob","age":25}]
+```
+
+`--json` is mutually exclusive with `-d`/`--delimiter`, `--tsv`, and `-H`/`--header`.
+
 Chain queries by piping back in — useful for two-pass aggregations:
 
 ```sh
@@ -154,6 +172,7 @@ $ cat events.csv \
 | `--tsv` | Alias for `--delimiter '\t'` |
 | `--no-type-inference` | Treat all columns as TEXT (skip auto-detection) |
 | `-H`, `--header` | Print column names as the first output row |
+| `--json` | Output results as a JSON array of objects (mutually exclusive with `-d`, `--tsv`, `-H`) |
 | `-h`, `--help` | Show usage help and exit |
 | `-V`, `--version` | Print version and exit |
 

--- a/docs/sql-pipe.1.scd
+++ b/docs/sql-pipe.1.scd
@@ -9,7 +9,7 @@ SYNOPSIS
 DESCRIPTION
 	sql-pipe reads CSV data from standard input, loads it into an in-memory SQLite
 	database table named *t*, executes the provided SQL query, and prints the results
-	as CSV to standard output.
+	as CSV (or JSON when *--json* is used) to standard output.
 
 	This tool is useful for quick data transformations, filtering, grouping, and
 	aggregations on CSV files without manual SQL database setup.
@@ -44,7 +44,13 @@ OPTIONS
 		Print a header row with column names as the first line of output. Column
 		names are taken from the SQL column alias or original name. The output
 		remains valid CSV that can be piped back into sql-pipe. Header output is
-		off by default.
+		off by default. Cannot be combined with *--json*.
+
+	*--json*
+		Output results as a JSON array of objects instead of CSV. Each row
+		becomes a JSON object with column names as keys and typed values (string,
+		number, or null). Mutually exclusive with *--delimiter*, *--tsv*, and
+		*--header*.
 
 	*-h, --help*
 		Print the help message and exit with code 0.
@@ -88,6 +94,13 @@ EXAMPLES
 	Process tab-separated input (TSV):
 
 		$ cat data.tsv | sql-pipe --tsv 'SELECT \* FROM t'
+
+	Output results as JSON:
+
+		$ printf 'name,age\nAlice,30\nBob,25' | sql-pipe --json 'SELECT \* FROM t'
+
+	Output:++
+	[{"name":"Alice","age":30},{"name":"Bob","age":25}]
 
 EXIT CODES
 	*0*


### PR DESCRIPTION
## Summary

- Documents the `--json` flag (implemented in #44 / PR #74) in README.md (Flags table + usage example + incompatibility note) and `docs/sql-pipe.1.scd` (OPTIONS section + example + DESCRIPTION update)
- Adds Alpine Linux `.apk` install instructions to README.md between the RPM and AUR sections

Closes #76