### PR TITLE
ci: fix release-drafter duplicate entries and label/prefix mismatch

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,20 +1,50 @@
-"type:docs":
+# Labels are applied based on PR title prefix (Conventional Commits) first,
+# then fall back to changed-file globs. The title-based rules take precedence
+# because they are listed first and actions/labeler applies the first match.
+
+"type:feature":
+  - head-branch:
+      - "/^feat/"
+  - title:
+      - "/^feat(\\(.+\\))?:/i"
   - changed-files:
       - any-glob-to-any-file:
-          - "**/*.md"
-          - "LICENSE*"
-          - "CHANGELOG*"
+          - "src/**"
+
+"type:bug":
+  - head-branch:
+      - "/^fix/"
+  - title:
+      - "/^fix(\\(.+\\))?:/i"
 
 "type:chore":
+  - head-branch:
+      - "/^chore/"
+      - "/^ci/"
+      - "/^test/"
+      - "/^refactor/"
+      - "/^build/"
+  - title:
+      - "/^chore(\\(.+\\))?:/i"
+      - "/^ci(\\(.+\\))?:/i"
+      - "/^test(\\(.+\\))?:/i"
+      - "/^refactor(\\(.+\\))?:/i"
+      - "/^build(\\(.+\\))?:/i"
   - changed-files:
       - any-glob-to-any-file:
-          - ".github/**"
           - "build.zig"
           - "build.zig.zon"
           - ".gitignore"
           - ".editorconfig"
 
-"type:feature":
+"type:docs":
+  - head-branch:
+      - "/^docs/"
+  - title:
+      - "/^docs(\\(.+\\))?:/i"
   - changed-files:
       - any-glob-to-any-file:
-          - "src/**"
+          - "**/*.md"
+          - "docs/**"
+          - "LICENSE*"
+          - "CHANGELOG*"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -6,25 +6,66 @@ template: |
   $CHANGES
 
   **Full Changelog**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION
+
+autolabeler:
+  - label: "type:feature"
+    title:
+      - "/^feat(\\(.+\\))?:/i"
+  - label: "type:bug"
+    title:
+      - "/^fix(\\(.+\\))?:/i"
+  - label: "type:chore"
+    title:
+      - "/^chore(\\(.+\\))?:/i"
+      - "/^ci(\\(.+\\))?:/i"
+      - "/^test(\\(.+\\))?:/i"
+      - "/^refactor(\\(.+\\))?:/i"
+      - "/^build(\\(.+\\))?:/i"
+  - label: "type:docs"
+    title:
+      - "/^docs(\\(.+\\))?:/i"
+
 categories:
   - title: "🚀 Features"
     labels:
       - "type:feature"
+    exclude-labels:
+      - "type:bug"
+      - "type:chore"
+      - "type:docs"
+      - "type:spike"
   - title: "🐛 Bug Fixes"
     labels:
       - "type:bug"
+    exclude-labels:
+      - "type:feature"
+      - "type:chore"
+      - "type:docs"
+      - "type:spike"
   - title: "🧰 Maintenance"
     labels:
       - "type:chore"
       - "tech-debt"
+    exclude-labels:
+      - "type:feature"
+      - "type:bug"
+      - "type:docs"
+      - "type:spike"
   - title: "📝 Documentation"
     labels:
       - "type:docs"
+    exclude-labels:
+      - "type:feature"
+      - "type:bug"
+      - "type:chore"
+      - "type:spike"
   - title: "🔬 Spikes & Research"
     labels:
       - "type:spike"
+
 change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
 change-title-escapes: '\<*_&'
+
 version-resolver:
   major:
     labels:


### PR DESCRIPTION
## Summary

Addresses both action items from the [Sprint 4 Retrospective (#78)](https://github.com/vmvarela/sql-pipe/issues/78):

**Problem 1 — Duplicate entries in release notes** (PR #74 appeared in both Features and Maintenance):
- Root cause: PR #74 had both `type:feature` and `type:chore` labels
- Fix: add `exclude-labels` to each category in `release-drafter.yml` so a PR only appears in the first matching section

**Problem 2 — PR title prefix vs. label mismatch** (PR #75 had `feat:` title but `type:chore` label → appeared in Maintenance):
- Root cause: `labeler.yml` matched `.github/**` files → `type:chore` regardless of the commit prefix
- Fix 1: add `autolabeler` rules to `release-drafter.yml` mapping Conventional Commit prefixes to `type:*` labels
- Fix 2: update `labeler.yml` with `title` and `head-branch` pattern rules for all Conventional Commit prefixes; remove `.github/**` glob from `type:chore` (CI/packaging PRs should be typed by their title, not their file paths)

## Changes

- `.github/release-drafter.yml` — added `autolabeler` block + `exclude-labels` per category
- `.github/labeler.yml` — added `title`/`head-branch` rules; removed `.github/**` from `type:chore`