### PR TITLE
fix: apply RFC 4180 quoting to CSV output fields

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -538,7 +538,7 @@ fn printRow(
         } else {
             const ptr = c.sqlite3_column_text(stmt, i);
             if (ptr != null) {
-                try writer.writeAll(std.mem.span(@as([*:0]const u8, @ptrCast(ptr))));
+                try writeField(writer, std.mem.span(@as([*:0]const u8, @ptrCast(ptr))));
             } else {
                 try writer.writeAll("NULL");
             }


### PR DESCRIPTION
## Summary

- **Fixes #102** — CSV output now properly quotes fields containing commas, double quotes, or newlines per RFC 4180.
- `printRow` was writing field values verbatim via `writer.writeAll`; changed to route through `writeField` (already used by `printHeaderRow`), which applies RFC 4180 quoting rules.

## Before / After

| Input field | Before (broken) | After (correct) |
|---|---|---|
| `has a "nickname"` | `has a "nickname"` | `"has a ""nickname"""` |
| `value, with comma` | `value, with comma` | `"value, with comma"` |

## Change

One-line fix in `src/main.zig:541` — replace `writer.writeAll(...)` with `writeField(writer, ...)`.