### PR TITLE
ci: consolidate homebrew publishing to vmvarela/homebrew-tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -230,7 +230,7 @@ jobs:
           echo "==> Generated formula for sql-pipe ${VERSION}:"
           cat sql-pipe.rb
 
-          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/vmvarela/homebrew-sql-pipe.git" tap
+          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/vmvarela/homebrew-tap.git" tap
           mkdir -p tap/Formula
           cp sql-pipe.rb tap/Formula/sql-pipe.rb
           cd tap

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ curl -s https://example.com/data.csv | sql-pipe 'SELECT region, SUM(revenue) F
 **macOS / Linux via Homebrew:**
 
 ```sh
-brew tap vmvarela/sql-pipe
+brew tap vmvarela/homebrew-tap
 brew install sql-pipe
 ```
 


### PR DESCRIPTION
Change the Homebrew tap repository from `vmvarela/homebrew-sql-pipe` to `vmvarela/homebrew-tap` so all packages can be published to a single shared tap.