### PR TITLE
chore: fix release-drafter duplicate entries across categories

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,15 +1,12 @@
-# Labels are applied based on PR title prefix (Conventional Commits) first,
-# then fall back to changed-file globs. The title-based rules take precedence
-# because they are listed first and actions/labeler applies the first match.
+# Labels are applied based on PR title prefix (Conventional Commits) and branch name.
+# File-based rules are intentionally omitted: they cause multiple type:* labels to be
+# applied to a single PR, which leads to duplicate entries in release notes.
 
 "type:feature":
   - head-branch:
       - "/^feat/"
   - title:
       - "/^feat(\\(.+\\))?:/i"
-  - changed-files:
-      - any-glob-to-any-file:
-          - "src/**"
 
 "type:bug":
   - head-branch:
@@ -30,21 +27,9 @@
       - "/^test(\\(.+\\))?:/i"
       - "/^refactor(\\(.+\\))?:/i"
       - "/^build(\\(.+\\))?:/i"
-  - changed-files:
-      - any-glob-to-any-file:
-          - "build.zig"
-          - "build.zig.zon"
-          - ".gitignore"
-          - ".editorconfig"
 
 "type:docs":
   - head-branch:
       - "/^docs/"
   - title:
       - "/^docs(\\(.+\\))?:/i"
-  - changed-files:
-      - any-glob-to-any-file:
-          - "**/*.md"
-          - "docs/**"
-          - "LICENSE*"
-          - "CHANGELOG*"

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -34,6 +34,7 @@ categories:
       - "type:chore"
       - "type:docs"
       - "type:spike"
+      - "dependencies"
   - title: "🐛 Bug Fixes"
     labels:
       - "type:bug"
@@ -42,6 +43,7 @@ categories:
       - "type:chore"
       - "type:docs"
       - "type:spike"
+      - "dependencies"
   - title: "🧰 Maintenance"
     labels:
       - "type:chore"
@@ -51,6 +53,7 @@ categories:
       - "type:bug"
       - "type:docs"
       - "type:spike"
+      - "dependencies"
   - title: "📝 Documentation"
     labels:
       - "type:docs"
@@ -59,9 +62,15 @@ categories:
       - "type:bug"
       - "type:chore"
       - "type:spike"
+      - "dependencies"
   - title: "🔬 Spikes & Research"
     labels:
       - "type:spike"
+    exclude-labels:
+      - "dependencies"
+  - title: "⬆️ Dependency Updates"
+    labels:
+      - "dependencies"
 
 change-template: "- $TITLE (#$NUMBER) @$AUTHOR"
 change-title-escapes: '\<*_&'


### PR DESCRIPTION
## Summary

Fixes #117

Root cause: `labeler.yml` had `changed-files` rules that applied multiple conflicting `type:*` labels to a single PR. For example, a `feat:` PR touching `README.md` would get both `type:feature` (from `src/**` glob) and `type:docs` (from `**/*.md` glob), causing the same PR to appear in multiple release-drafter categories.

## Changes

### `.github/labeler.yml`
- Removed all `changed-files` rules from `type:*` labels
- Type is now determined solely by conventional commit prefix in PR title or branch name — no file-path ambiguity

### `.github/release-drafter.yml`
- Added `⬆️ Dependency Updates` category for Dependabot PRs (`labels: [dependencies]`)
- Added `dependencies` to `exclude-labels` of all other categories to ensure Dependabot PRs land only in the new category

## Acceptance Criteria

- [x] Each merged PR appears in exactly one category in the generated release notes
- [x] `feat:` commits → Features only
- [x] `fix:` commits → Bug Fixes only
- [x] `chore:`/`ci:` commits → Maintenance only
- [x] `docs:` commits → Documentation only
- [x] Dependabot PRs → Dependency Updates only