### PR TITLE
fix: replace dnf config-manager --add-repo with curl to support DNF5

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ Replace `VERSION` with the release version (e.g. `0.3.0`) and `amd64` with your 
 **Fedora / RHEL / openSUSE (RPM repository):**
 
 ```sh
-sudo dnf config-manager --add-repo https://vmvarela.github.io/rpm-packages/vmvarela.repo
+sudo curl -fsSL https://vmvarela.github.io/rpm-packages/vmvarela.repo \
+  -o /etc/yum.repos.d/vmvarela.repo
 sudo dnf install sql-pipe
 ```
 


### PR DESCRIPTION
## Problem

`dnf config-manager --add-repo` es sintaxis de DNF4. DNF5 (Fedora 41+, RHEL 10+) eliminó el argumento `--add-repo`, haciendo que las instrucciones documentadas fallen:

```
Unknown argument "--add-repo" for command "config-manager".
```

Al no añadirse el repo, `dnf install sql-pipe` también falla con `No match for argument: sql-pipe`.

## Fix

Reemplazado con `curl` directo a `/etc/yum.repos.d/`, compatible con DNF4 y DNF5:

```sh
sudo curl -fsSL https://vmvarela.github.io/rpm-packages/vmvarela.repo \
  -o /etc/yum.repos.d/vmvarela.repo
sudo dnf install sql-pipe
```

Note: the RPM repo itself is fine — `sql-pipe 0.7.1` is correctly indexed in the repodata.