### PR TITLE
feat: add XML input/output format support

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,19 @@ $ printf 'name,age\nAlice,30\nBob,25' | sql-pipe --json 'SELECT * FROM t'
 
 `--json` is mutually exclusive with `-H`/`--header`. It can be combined with `-d`/`--delimiter` and `--tsv` to read non-comma-separated input.
 
+For XML input and output, use `-I xml` / `-O xml`. By default the root element is `<results>` and each row is `<row>`. Override with `--xml-root` and `--xml-row`:
+
+```sh
+$ printf 'name,age\nAlice,30\nBob,25' | sql-pipe -O xml 'SELECT * FROM t'
+<?xml version="1.0" encoding="UTF-8"?>
+<results>
+<row><name>Alice</name><age>30</age></row>
+<row><name>Bob</name><age>25</age></row>
+</results>
+
+$ cat data.xml | sql-pipe -I xml 'SELECT name FROM t WHERE age > 25'
+```
+
 Chain queries by piping back in — useful for two-pass aggregations. Pass `-H` to the first call so the second one sees column names:
 
 ```sh
@@ -208,15 +221,17 @@ $ cat events.csv \
 |------|-------------|
 | `-d`, `--delimiter <char>` | Input field delimiter (single character, default `,`) |
 | `--tsv` | Alias for `--delimiter '\t'` |
-| `-I`, `--input-format <fmt>` | Input format: `csv` (default), `tsv`, `json`, `ndjson` |
-| `-O`, `--output-format <fmt>` | Output format: `csv` (default), `tsv`, `json`, `ndjson` |
+| `-I`, `--input-format <fmt>` | Input format: `csv` (default), `tsv`, `json`, `ndjson`, `xml` |
+| `-O`, `--output-format <fmt>` | Output format: `csv` (default), `tsv`, `json`, `ndjson`, `xml` |
 | `--no-type-inference` | Treat all columns as TEXT (skip auto-detection) |
 | `-H`, `--header` | Print column names as the first output row |
 | `--json` | Alias for `--output-format json` (mutually exclusive with `-H`) |
 | `--max-rows <n>` | Stop if more than `n` data rows are read (exit 1) |
-| `--validate` | Parse the entire input and print a summary (`OK: <n> rows, <m> columns (col TYPE, ...)`) to stdout. Exit 0 on success, exit 2 on parse error. No query required. Compatible with `--delimiter`, `--tsv`, `--no-type-inference`, `-I`/`--input-format` (csv, tsv, json, ndjson). JSON/NDJSON columns are reported as TEXT. |
-| `--columns` | Read the CSV header row, print each column name on its own line, and exit 0. With `-v`/`--verbose`, also shows the inferred type per column (`name INTEGER`). Respects `--delimiter` and `--tsv`. Mutually exclusive with a query argument. |
+| `--validate` | Parse the entire input and print a summary (`OK: <n> rows, <m> columns (col TYPE, ...)`) to stdout. Exit 0 on success, exit 2 on parse error. No query required. Compatible with `--delimiter`, `--tsv`, `--no-type-inference`, `-I`/`--input-format` (csv, tsv, json, ndjson, xml). JSON/NDJSON/XML columns are reported as TEXT. |
+| `--columns` | Read the input header, print each column name on its own line, and exit 0. Supports CSV, TSV, JSON, NDJSON, and XML input. With `-v`/`--verbose`, also shows the inferred type per column (`name INTEGER`). Respects `--delimiter` and `--tsv`. Mutually exclusive with a query argument. |
 | `--sample [<n>]` | Print a schema comment block to stderr and the first `<n>` data rows to stdout as CSV (default: `n=10`). The schema block lists each column name and its inferred type, prefixed with `#`. Implies `--header`. Compatible with `--delimiter` and `--tsv`. Mutually exclusive with `--json` and a query argument. No query required. |
+| `--xml-root <name>` | Root element name for XML I/O (default: `results`) |
+| `--xml-row <name>` | Row element name for XML I/O (default: `row`) |
 | `--output <file>` | Write results to the given file instead of stdout. Creates or overwrites the file. Exits 1 if the file cannot be created. |
 | `-v`, `--verbose` | Print `Loaded <n> rows in <t>s` to stderr after loading (always on TTY; forced with flag) |
 | `-s`, `--silent` | Suppress `Loaded <n> rows in <t>s` and the progress counter from stderr unconditionally. Cannot be combined with `-v`/`--verbose` |

--- a/build.zig
+++ b/build.zig
@@ -593,7 +593,7 @@ pub fn build(b: *std.Build) void {
     // Integration test 57: unknown input format → error exit 1
     const test_bad_input_format = b.addSystemCommand(&.{
         "bash", "-c",
-        \\msg=$(printf '' | ./zig-out/bin/sql-pipe --input-format xml 'SELECT 1' 2>&1 >/dev/null; echo "EXIT:$?")
+        \\msg=$(printf '' | ./zig-out/bin/sql-pipe --input-format parquet 'SELECT 1' 2>&1 >/dev/null; echo "EXIT:$?")
         \\echo "$msg" | grep -q 'unknown input format' && echo "$msg" | grep -q 'EXIT:1'
     });
     test_bad_input_format.step.dependOn(b.getInstallStep());
@@ -602,7 +602,7 @@ pub fn build(b: *std.Build) void {
     // Integration test 58: unknown output format → error exit 1
     const test_bad_output_format = b.addSystemCommand(&.{
         "bash", "-c",
-        \\msg=$(printf 'a\n1\n' | ./zig-out/bin/sql-pipe --output-format xml 'SELECT * FROM t' 2>&1 >/dev/null; echo "EXIT:$?")
+        \\msg=$(printf 'a\n1\n' | ./zig-out/bin/sql-pipe --output-format parquet 'SELECT * FROM t' 2>&1 >/dev/null; echo "EXIT:$?")
         \\echo "$msg" | grep -q 'unknown output format' && echo "$msg" | grep -q 'EXIT:1'
     });
     test_bad_output_format.step.dependOn(b.getInstallStep());
@@ -1010,6 +1010,71 @@ pub fn build(b: *std.Build) void {
     });
     test_delimiter_too_long_error.step.dependOn(b.getInstallStep());
     test_step.dependOn(&test_delimiter_too_long_error.step);
+
+    // ─── XML input/output integration tests ─────────────────────────────────
+
+    // Integration test 99: XML output format emits correct structure
+    const test_xml_output = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\result=$(printf 'name,age\nAlice,30\nBob,25\n' \
+        \\    | ./zig-out/bin/sql-pipe --output-format xml 'SELECT * FROM t ORDER BY name')
+        \\expected=$(printf '<?xml version="1.0" encoding="UTF-8"?>\n<results>\n<row><name>Alice</name><age>30</age></row>\n<row><name>Bob</name><age>25</age></row>\n</results>')
+        \\[ "$result" = "$expected" ]
+    });
+    test_xml_output.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_xml_output.step);
+
+    // Integration test 100: XML input can be queried
+    const test_xml_input = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\result=$(printf '<?xml version="1.0"?>\n<results>\n<row><name>Alice</name><age>30</age></row>\n<row><name>Bob</name><age>25</age></row>\n</results>\n' \
+        \\    | ./zig-out/bin/sql-pipe --input-format xml 'SELECT name FROM t ORDER BY name')
+        \\expected=$(printf 'Alice\nBob')
+        \\[ "$result" = "$expected" ]
+    });
+    test_xml_input.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_xml_input.step);
+
+    // Integration test 101: XML roundtrip (xml in → xml out)
+    const test_xml_roundtrip = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\result=$(printf '<?xml version="1.0"?>\n<results>\n<row><name>Alice</name><age>30</age></row>\n</results>\n' \
+        \\    | ./zig-out/bin/sql-pipe -I xml -O xml 'SELECT * FROM t')
+        \\echo "$result" | grep -q '<name>Alice</name>' && echo "$result" | grep -q '<age>30</age>'
+    });
+    test_xml_roundtrip.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_xml_roundtrip.step);
+
+    // Integration test 102: --columns with XML input lists column names
+    const test_xml_columns = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\result=$(printf '<?xml version="1.0"?>\n<results>\n<row><name>Alice</name><age>30</age></row>\n</results>\n' \
+        \\    | ./zig-out/bin/sql-pipe -I xml --columns)
+        \\expected=$(printf 'name\nage')
+        \\[ "$result" = "$expected" ]
+    });
+    test_xml_columns.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_xml_columns.step);
+
+    // Integration test 103: --validate with XML input prints summary
+    const test_xml_validate = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\result=$(printf '<?xml version="1.0"?>\n<results>\n<row><name>Alice</name><age>30</age></row>\n<row><name>Bob</name><age>25</age></row>\n</results>\n' \
+        \\    | ./zig-out/bin/sql-pipe -I xml --validate)
+        \\echo "$result" | grep -q 'OK: 2 rows'
+    });
+    test_xml_validate.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_xml_validate.step);
+
+    // Integration test 104: --xml-root and --xml-row customize element names
+    const test_xml_custom_elements = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\result=$(printf 'name,age\nAlice,30\n' \
+        \\    | ./zig-out/bin/sql-pipe -O xml --xml-root data --xml-row record 'SELECT * FROM t')
+        \\echo "$result" | grep -q '<data>' && echo "$result" | grep -q '<record>' && echo "$result" | grep -q '</data>'
+    });
+    test_xml_custom_elements.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_xml_custom_elements.step);
 
     // Unit tests for the RFC 4180 CSV parser (src/csv.zig)
     const unit_tests = b.addTest(.{

--- a/build.zig
+++ b/build.zig
@@ -1076,6 +1076,92 @@ pub fn build(b: *std.Build) void {
     test_xml_custom_elements.step.dependOn(b.getInstallStep());
     test_step.dependOn(&test_xml_custom_elements.step);
 
+    // Integration test 105: XML entities en input — roundtrip correcto
+    const test_xml_entities_input = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\result=$(printf '<?xml version="1.0"?>\n<results>\n<row><name>Alice &amp; Bob</name></row>\n</results>\n' \
+        \\    | ./zig-out/bin/sql-pipe -I xml 'SELECT name FROM t')
+        \\[ "$result" = "Alice & Bob" ]
+    });
+    test_xml_entities_input.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_xml_entities_input.step);
+
+    // Integration test 106: NULL en output XML → elemento vacío, no "NULL"
+    const test_xml_null_output = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\result=$(printf 'name\nAlice\n' \
+        \\    | ./zig-out/bin/sql-pipe -O xml 'SELECT name, NULL as age FROM t')
+        \\echo "$result" | grep -q '<age></age>'
+    });
+    test_xml_null_output.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_xml_null_output.step);
+
+    // Integration test 107: Documento XML vacío → error con "empty input"
+    const test_xml_empty_input = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\msg=$(printf '' | ./zig-out/bin/sql-pipe -I xml 'SELECT 1' 2>&1; echo "EXIT:$?")
+        \\echo "$msg" | grep -q 'empty input' && echo "$msg" | grep -qv 'EXIT:0'
+    });
+    test_xml_empty_input.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_xml_empty_input.step);
+
+    // Integration test 108: Root sin rows → error con "no row elements"
+    const test_xml_no_rows = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\msg=$(printf '<root></root>' | ./zig-out/bin/sql-pipe -I xml 'SELECT 1' 2>&1; echo "EXIT:$?")
+        \\echo "$msg" | grep -q 'no row elements' && echo "$msg" | grep -qv 'EXIT:0'
+    });
+    test_xml_no_rows.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_xml_no_rows.step);
+
+    // Integration test 109: --sample rechazado con XML → exit no-cero con mensaje claro
+    const test_xml_sample_rejected = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\msg=$(printf '<r><row><a>1</a></row></r>' | ./zig-out/bin/sql-pipe -I xml --sample 2>&1; echo "EXIT:$?")
+        \\echo "$msg" | grep -q 'sample' && echo "$msg" | grep -qv 'EXIT:0'
+    });
+    test_xml_sample_rejected.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_xml_sample_rejected.step);
+
+    // Integration test 110: Self-closing column → NULL en SQLite (SELECT devuelve vacío)
+    const test_xml_self_closing_null = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\result=$(printf '<?xml version="1.0"?>\n<results>\n<row><name/><age>30</age></row>\n</results>\n' \
+        \\    | ./zig-out/bin/sql-pipe -I xml 'SELECT COALESCE(name, "NULL_VALUE") FROM t')
+        \\[ "$result" = "NULL_VALUE" ]
+    });
+    test_xml_self_closing_null.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_xml_self_closing_null.step);
+
+    // Integration test 111: Columnas en orden distinto entre rows → bind-by-name correcto
+    const test_xml_column_order = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\result=$(printf '<?xml version="1.0"?>\n<results>\n<row><name>Alice</name><age>30</age></row>\n<row><age>25</age><name>Bob</name></row>\n</results>\n' \
+        \\    | ./zig-out/bin/sql-pipe -I xml 'SELECT name || ":" || age FROM t ORDER BY name')
+        \\[ "$result" = "$(printf 'Alice:30\nBob:25')" ]
+    });
+    test_xml_column_order.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_xml_column_order.step);
+
+    // Integration test 112: Atributos en elementos → ignorados, contenido preservado
+    const test_xml_attrs_ignored = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\result=$(printf '<?xml version="1.0"?>\n<results>\n<row id="1"><name class="primary">Alice</name></row>\n</results>\n' \
+        \\    | ./zig-out/bin/sql-pipe -I xml 'SELECT name FROM t')
+        \\[ "$result" = "Alice" ]
+    });
+    test_xml_attrs_ignored.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_xml_attrs_ignored.step);
+
+    // Integration test 113: Float-as-integer → emitido como entero en XML
+    const test_xml_float_as_int = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\result=$(printf 'x\n1\n' | ./zig-out/bin/sql-pipe -O xml 'SELECT CAST(30.0 AS REAL) as val')
+        \\echo "$result" | grep -q '<val>30</val>'
+    });
+    test_xml_float_as_int.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_xml_float_as_int.step);
+
     // Unit tests for the RFC 4180 CSV parser (src/csv.zig)
     const unit_tests = b.addTest(.{
         .root_module = b.createModule(.{
@@ -1087,4 +1173,27 @@ pub fn build(b: *std.Build) void {
     const run_unit_tests = b.addRunArtifact(unit_tests);
     const unit_test_step = b.step("unit-test", "Run CSV unit tests");
     unit_test_step.dependOn(&run_unit_tests.step);
+
+    // Unit tests for the XML parser (src/xml.zig)
+    const xml_unit_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/xml.zig"),
+            .target = target,
+            .optimize = optimize,
+            .link_libc = true,
+        }),
+    });
+    xml_unit_tests.root_module.addImport("c", translate_c.createModule());
+    if (bundle_sqlite) {
+        xml_unit_tests.root_module.addIncludePath(b.path("lib"));
+        xml_unit_tests.root_module.addCSourceFile(.{
+            .file = b.path("lib/sqlite3.c"),
+            .flags = &.{"-DSQLITE_OMIT_LOAD_EXTENSION=1"},
+        });
+    } else {
+        xml_unit_tests.root_module.linkSystemLibrary("sqlite3", .{});
+    }
+    const run_xml_unit_tests = b.addRunArtifact(xml_unit_tests);
+    test_step.dependOn(&run_xml_unit_tests.step);
+    unit_test_step.dependOn(&run_xml_unit_tests.step);
 }

--- a/docs/sql-pipe.1.scd
+++ b/docs/sql-pipe.1.scd
@@ -72,22 +72,33 @@ OPTIONS
 		stderr is a TTY. Useful for producing clean stderr in interactive
 		terminals. Cannot be combined with *-v* / *--verbose*.
 
+	*--xml-root* <name>
+		Root element name used when reading or writing XML (default: *results*).
+		The output document is wrapped in *<name>...</name>*. Also used as the
+		expected root tag when parsing XML input.
+
+	*--xml-row* <name>
+		Row element name used when reading or writing XML (default: *row*).
+		Each result row is emitted as *<name><col>value</col>...</name>*.
+
 	*--validate*
 		Parse the entire input without executing a SQL query. On success,
 		prints a one-line summary to standard output:
 		*OK: <n> rows, <m> columns (<col> <TYPE>, ...)* and exits 0.
 		On parse error, prints the error message and exits 2. Compatible
 		with *--delimiter*, *--tsv*, *--no-type-inference*, and
-		*-I* / *--input-format* (csv, tsv, json, ndjson). JSON and NDJSON
-		columns are reported as TEXT. Mutually exclusive with a query
+		*-I* / *--input-format* (csv, tsv, json, ndjson, xml). JSON, NDJSON,
+		and XML columns are reported as TEXT. Mutually exclusive with a query
 		argument.
 
 	*--columns*
-		Read the CSV header row, print each column name on its own line to
-		standard output, and exit with code 0. When combined with *-v* /
-		*--verbose*, also shows the inferred type (INTEGER, REAL, or TEXT)
-		for each column, using the first 100 data rows for inference. Respects
-		*--delimiter* and *--tsv*. Mutually exclusive with a query argument.
+		Read the input header, print each column name on its own line to
+		standard output, and exit with code 0. Supported for CSV, TSV,
+		JSON, NDJSON, and XML input. When combined with *-v* / *--verbose*,
+		also shows the inferred type (INTEGER, REAL, or TEXT) for each column
+		(CSV/TSV only; other formats always show TEXT), using the first 100
+		data rows for inference. Respects *--delimiter* and *--tsv*.
+		Mutually exclusive with a query argument.
 
 	*--sample* [<n>]
 		Print a schema comment block to standard error and the first <n> data
@@ -156,6 +167,21 @@ EXAMPLES
 
 	Output:++
 	[{"name":"Alice","age":30},{"name":"Bob","age":25}]
+
+	Convert CSV to XML:
+
+		$ printf 'name,age\nAlice,30\nBob,25' | sql-pipe -O xml 'SELECT \* FROM t'
+
+	Output:++
+	<?xml version="1.0" encoding="UTF-8"?>++
+	<results>++
+	<row><name>Alice</name><age>30</age></row>++
+	<row><name>Bob</name><age>25</age></row>++
+	</results>
+
+	Query XML input:
+
+		$ cat data.xml | sql-pipe -I xml 'SELECT name FROM t WHERE age > 25'
 
 	Preview schema and first 3 rows of a CSV file:
 

--- a/src/json.zig
+++ b/src/json.zig
@@ -22,95 +22,17 @@
 const std = @import("std");
 const c = @import("c");
 
-/// SQLITE_STATIC: caller manages string lifetime; SQLite must not free it.
-const sqlite_static: c.sqlite3_destructor_type = null;
+const sqlite_helpers = @import("sqlite.zig");
 
-const exit_usage: u8 = 1;
-const exit_parse: u8 = 2;
-const exit_sql: u8 = 3;
-
-// ─── Internal utilities ───────────────────────────────
-
-fn fatal(comptime fmt: []const u8, writer: *std.Io.Writer, code: u8, args: anytype) noreturn {
-    writer.print("error: " ++ fmt ++ "\n", args) catch |err| std.log.err("failed to write error: {}", .{err});
-    writer.flush() catch |err| std.log.err("failed to flush: {}", .{err});
-    std.process.exit(code);
-}
-
-/// Create table `t` with all-TEXT columns. Column names are double-quote–escaped
-/// per SQL identifier rules.
-fn createAllTextTable(
-    allocator: std.mem.Allocator,
-    db: *c.sqlite3,
-    cols: []const []const u8,
-    writer: *std.Io.Writer,
-) void {
-    var sql: std.ArrayList(u8) = .empty;
-    defer sql.deinit(allocator);
-
-    sql.appendSlice(allocator, "CREATE TABLE t (") catch fatal("out of memory", writer, exit_parse, .{});
-    for (cols, 0..) |col, i| {
-        if (i > 0) sql.appendSlice(allocator, ", ") catch fatal("out of memory", writer, exit_parse, .{});
-        sql.append(allocator, '"') catch fatal("out of memory", writer, exit_parse, .{});
-        for (col) |ch| {
-            if (ch == '"') sql.append(allocator, '"') catch fatal("out of memory", writer, exit_parse, .{});
-            sql.append(allocator, ch) catch fatal("out of memory", writer, exit_parse, .{});
-        }
-        sql.appendSlice(allocator, "\" TEXT") catch fatal("out of memory", writer, exit_parse, .{});
-    }
-    sql.appendSlice(allocator, ")") catch fatal("out of memory", writer, exit_parse, .{});
-    sql.append(allocator, 0) catch fatal("out of memory", writer, exit_parse, .{});
-
-    var errmsg: [*c]u8 = null;
-    if (c.sqlite3_exec(db, sql.items.ptr, null, null, &errmsg) != c.SQLITE_OK) {
-        const msg = if (errmsg != null) std.mem.span(errmsg) else std.mem.span(c.sqlite3_errmsg(db));
-        if (errmsg != null) c.sqlite3_free(errmsg);
-        fatal("{s}", writer, exit_sql, .{msg});
-    }
-}
-
-/// Prepare `INSERT INTO t VALUES (?, …, ?)` with n parameters.
-fn prepareInsertStmt(
-    allocator: std.mem.Allocator,
-    db: *c.sqlite3,
-    n: usize,
-    writer: *std.Io.Writer,
-) *c.sqlite3_stmt {
-    var sql: std.ArrayList(u8) = .empty;
-    defer sql.deinit(allocator);
-
-    sql.appendSlice(allocator, "INSERT INTO t VALUES (") catch fatal("out of memory", writer, exit_parse, .{});
-    for (0..n) |i| {
-        if (i > 0) sql.append(allocator, ',') catch fatal("out of memory", writer, exit_parse, .{});
-        sql.append(allocator, '?') catch fatal("out of memory", writer, exit_parse, .{});
-    }
-    sql.appendSlice(allocator, ")") catch fatal("out of memory", writer, exit_parse, .{});
-    sql.append(allocator, 0) catch fatal("out of memory", writer, exit_parse, .{});
-
-    var stmt: ?*c.sqlite3_stmt = null;
-    if (c.sqlite3_prepare_v2(db, sql.items.ptr, -1, &stmt, null) != c.SQLITE_OK)
-        fatal("{s}", writer, exit_sql, .{std.mem.span(c.sqlite3_errmsg(db))});
-    return stmt.?;
-}
-
-fn beginTransaction(db: *c.sqlite3, writer: *std.Io.Writer) void {
-    var errmsg: [*c]u8 = null;
-    if (c.sqlite3_exec(db, "BEGIN TRANSACTION", null, null, &errmsg) != c.SQLITE_OK) {
-        const msg = if (errmsg != null) std.mem.span(errmsg) else std.mem.span(c.sqlite3_errmsg(db));
-        if (errmsg != null) c.sqlite3_free(errmsg);
-        fatal("{s}", writer, exit_sql, .{msg});
-    }
-}
-
-fn commitTransaction(db: *c.sqlite3, writer: *std.Io.Writer) void {
-    var errmsg: [*c]u8 = null;
-    if (c.sqlite3_exec(db, "COMMIT", null, null, &errmsg) != c.SQLITE_OK) {
-        const msg = if (errmsg != null) std.mem.span(errmsg) else std.mem.span(c.sqlite3_errmsg(db));
-        if (errmsg != null) c.sqlite3_free(errmsg);
-        fatal("{s}", writer, exit_sql, .{msg});
-    }
-    if (errmsg != null) c.sqlite3_free(errmsg);
-}
+const createAllTextTable = sqlite_helpers.createAllTextTable;
+const prepareInsertStmt = sqlite_helpers.prepareInsertStmt;
+const beginTransaction = sqlite_helpers.beginTransaction;
+const commitTransaction = sqlite_helpers.commitTransaction;
+const fatal = sqlite_helpers.fatal;
+const exit_usage = sqlite_helpers.exit_usage;
+const exit_parse = sqlite_helpers.exit_parse;
+const exit_sql = sqlite_helpers.exit_sql;
+const sqlite_static = sqlite_helpers.sqlite_static;
 
 // ─── Shared helpers ───────────────────────────────────
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -27,6 +27,8 @@ const SqlPipeError = error{
     InvalidMaxRows,
     InvalidInputFormat,
     InvalidOutputFormat,
+    MissingXmlFlagValue,
+    InvalidXmlName,
     OpenDbFailed,
     EmptyInput,
     EmptyColumnName,
@@ -251,6 +253,26 @@ fn parseOutputFormat(s: []const u8) SqlPipeError!OutputFormat {
     return error.InvalidOutputFormat;
 }
 
+/// isValidXmlName(s) → bool
+///
+/// Returns true iff s is a valid XML Name:
+///   NameStartChar: letter, '_', ':'
+///   NameChar: NameStartChar | digit | '-' | '.'
+fn isValidXmlName(s: []const u8) bool {
+    if (s.len == 0) return false;
+    switch (s[0]) {
+        'a'...'z', 'A'...'Z', '_', ':' => {},
+        else => return false,
+    }
+    for (s[1..]) |ch| {
+        switch (ch) {
+            'a'...'z', 'A'...'Z', '0'...'9', '-', '.', '_', ':' => {},
+            else => return false,
+        }
+    }
+    return true;
+}
+
 /// parseArgs(args) → ArgsResult
 /// Pre:  args is the full process argument slice; args[0] is the program name
 /// Post: result.parsed.query is the first non-flag argument
@@ -376,13 +398,13 @@ fn parseArgs(args: []const [:0]const u8) SqlPipeError!ArgsResult {
             output = trimmed;
         } else if (std.mem.eql(u8, arg, "--xml-root")) {
             i += 1;
-            if (i >= args.len) return error.MissingQuery;
+            if (i >= args.len) return error.MissingXmlFlagValue;
             xml_root = args[i];
         } else if (std.mem.startsWith(u8, arg, "--xml-root=")) {
             xml_root = arg["--xml-root=".len..];
         } else if (std.mem.eql(u8, arg, "--xml-row")) {
             i += 1;
-            if (i >= args.len) return error.MissingQuery;
+            if (i >= args.len) return error.MissingXmlFlagValue;
             xml_row = args[i];
         } else if (std.mem.startsWith(u8, arg, "--xml-row=")) {
             xml_row = arg["--xml-row=".len..];
@@ -438,6 +460,10 @@ fn parseArgs(args: []const [:0]const u8) SqlPipeError!ArgsResult {
     // --silent and --verbose are mutually exclusive
     if (silent and verbose)
         return error.SilentVerboseConflict;
+
+    // --xml-root and --xml-row must be valid XML element names
+    if (!isValidXmlName(xml_root) or !isValidXmlName(xml_row))
+        return error.InvalidXmlName;
 
     // --columns mode: list headers and exit
     if (list_columns)
@@ -1818,7 +1844,7 @@ fn runSample(
 ) void {
     switch (args.input_format) {
         .json, .ndjson, .xml => fatal(
-            "--sample only supports CSV and TSV input; use -I csv (default) or --tsv",
+            "--sample is only supported with CSV and TSV input",
             stderr_writer,
             .usage,
             .{},
@@ -2160,6 +2186,20 @@ pub fn main(init: std.process.Init.Minimal) void {
                 stderr_writer.writeAll("error: --sample requires a positive integer value\n") catch |werr| {
                     std.log.err("failed to write error message: {}", .{werr});
                 };
+                stderr_writer.flush() catch |ferr| std.log.err("failed to flush: {}", .{ferr});
+                std.process.exit(@intFromEnum(ExitCode.usage));
+            },
+            error.MissingXmlFlagValue => {
+                stderr_writer.writeAll(
+                    "error: --xml-root and --xml-row require a value\n",
+                ) catch |werr| std.log.err("failed to write error message: {}", .{werr});
+                stderr_writer.flush() catch |ferr| std.log.err("failed to flush: {}", .{ferr});
+                std.process.exit(@intFromEnum(ExitCode.usage));
+            },
+            error.InvalidXmlName => {
+                stderr_writer.writeAll(
+                    "error: --xml-root and --xml-row must be valid XML element names (letter/underscore first, then letters/digits/-/._/:)\n",
+                ) catch |werr| std.log.err("failed to write error message: {}", .{werr});
                 stderr_writer.flush() catch |ferr| std.log.err("failed to flush: {}", .{ferr});
                 std.process.exit(@intFromEnum(ExitCode.usage));
             },

--- a/src/main.zig
+++ b/src/main.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const c = @import("c");
 const csv = @import("csv.zig");
 const json = @import("json.zig");
+const xml = @import("xml.zig");
 const build_options = @import("build_options");
 
 const VERSION: []const u8 = build_options.version;
@@ -70,10 +71,10 @@ const ExitCode = enum(u8) {
 };
 
 /// Supported input formats.
-const InputFormat = enum { csv, tsv, json, ndjson };
+const InputFormat = enum { csv, tsv, json, ndjson, xml };
 
 /// Supported output formats.
-const OutputFormat = enum { csv, tsv, json, ndjson };
+const OutputFormat = enum { csv, tsv, json, ndjson, xml };
 
 /// Parsed command-line arguments.
 const ParsedArgs = struct {
@@ -98,6 +99,10 @@ const ParsedArgs = struct {
     silent: bool,
     /// Write results to this file path instead of stdout; null = write to stdout.
     output: ?[]const u8,
+    /// Root element name for XML output (default: "results").
+    xml_root: []const u8,
+    /// Row element name for XML output (default: "row").
+    xml_row: []const u8,
 };
 
 /// Arguments for `--columns` mode.
@@ -163,8 +168,8 @@ fn printUsage(writer: *std.Io.Writer) !void {
         \\Options:
         \\  -d, --delimiter <string>     Input field delimiter for CSV: 1–8 chars (default: ,)
         \\  --tsv                        Alias for --delimiter '\t'
-        \\  -I, --input-format <fmt>     Input format: csv (default), tsv, json, ndjson
-        \\  -O, --output-format <fmt>    Output format: csv (default), tsv, json, ndjson
+        \\  -I, --input-format <fmt>     Input format: csv (default), tsv, json, ndjson, xml
+        \\  -O, --output-format <fmt>    Output format: csv (default), tsv, json, ndjson, xml
         \\  --json                       Alias for --output-format json
         \\  --no-type-inference          Treat all columns as TEXT (CSV input only)
         \\  -H, --header                 Print column names as the first output row (CSV/TSV output only)
@@ -185,6 +190,8 @@ fn printUsage(writer: *std.Io.Writer) !void {
         \\                               Implies --header. Compatible with --delimiter and --tsv.
         \\                               Incompatible with --json and with a query argument.
         \\  --output <file>              Write results to file instead of stdout
+        \\  --xml-root <name>            Root element name for XML I/O (default: results)
+        \\  --xml-row <name>             Row element name for XML I/O (default: row)
         \\  -h, --help                   Show this help message and exit
         \\  -V, --version                Show version and exit
         \\
@@ -227,6 +234,7 @@ fn parseInputFormat(s: []const u8) SqlPipeError!InputFormat {
     if (std.mem.eql(u8, s, "tsv")) return .tsv;
     if (std.mem.eql(u8, s, "json")) return .json;
     if (std.mem.eql(u8, s, "ndjson")) return .ndjson;
+    if (std.mem.eql(u8, s, "xml")) return .xml;
     return error.InvalidInputFormat;
 }
 
@@ -239,6 +247,7 @@ fn parseOutputFormat(s: []const u8) SqlPipeError!OutputFormat {
     if (std.mem.eql(u8, s, "tsv")) return .tsv;
     if (std.mem.eql(u8, s, "json")) return .json;
     if (std.mem.eql(u8, s, "ndjson")) return .ndjson;
+    if (std.mem.eql(u8, s, "xml")) return .xml;
     return error.InvalidOutputFormat;
 }
 
@@ -265,6 +274,8 @@ fn parseArgs(args: []const [:0]const u8) SqlPipeError!ArgsResult {
     var list_columns = false;
     var validate = false;
     var output: ?[]const u8 = null;
+    var xml_root: []const u8 = "results";
+    var xml_row: []const u8 = "row";
     var sample_mode = false;
     var sample_n: usize = 10;
 
@@ -363,6 +374,18 @@ fn parseArgs(args: []const [:0]const u8) SqlPipeError!ArgsResult {
             const trimmed = std.mem.trim(u8, arg["--output=".len..], " \t");
             if (trimmed.len == 0) return error.InvalidOutputPath;
             output = trimmed;
+        } else if (std.mem.eql(u8, arg, "--xml-root")) {
+            i += 1;
+            if (i >= args.len) return error.MissingQuery;
+            xml_root = args[i];
+        } else if (std.mem.startsWith(u8, arg, "--xml-root=")) {
+            xml_root = arg["--xml-root=".len..];
+        } else if (std.mem.eql(u8, arg, "--xml-row")) {
+            i += 1;
+            if (i >= args.len) return error.MissingQuery;
+            xml_row = args[i];
+        } else if (std.mem.startsWith(u8, arg, "--xml-row=")) {
+            xml_row = arg["--xml-row=".len..];
         } else {
             if (query == null) query = arg;
         }
@@ -452,6 +475,8 @@ fn parseArgs(args: []const [:0]const u8) SqlPipeError!ArgsResult {
         .verbose = verbose,
         .silent = silent,
         .output = output,
+        .xml_root = xml_root,
+        .xml_row = xml_row,
     } };
 }
 
@@ -884,6 +909,8 @@ fn execQuery(
     writer: *std.Io.Writer,
     header: bool,
     output_format: OutputFormat,
+    xml_root: []const u8,
+    xml_row: []const u8,
 ) (SqlPipeError || std.mem.Allocator.Error || std.Io.Writer.Error)!void {
     const query_z = try allocator.dupeZ(u8, query);
     defer allocator.free(query_z);
@@ -942,6 +969,23 @@ fn execQuery(
             while (c.sqlite3_step(stmt) == c.SQLITE_ROW) {
                 try printRow(stmt.?, col_count, writer, out_delim);
             }
+        },
+        .xml => {
+            // Collect column names before stepping
+            var col_names = try allocator.alloc([*:0]const u8, @intCast(col_count));
+            defer allocator.free(col_names);
+            var ci: c_int = 0;
+            while (ci < col_count) : (ci += 1) {
+                col_names[@intCast(ci)] = c.sqlite3_column_name(stmt, ci);
+            }
+
+            try xml.writeXmlHeader(writer, xml_root);
+            // Loop invariant I: all SQLITE_ROW results returned so far have been written as XML rows
+            // Bounding function: number of remaining rows in the result set (finite)
+            while (c.sqlite3_step(stmt) == c.SQLITE_ROW) {
+                try xml.writeXmlRow(stmt.?, col_count, col_names, writer, xml_row);
+            }
+            try xml.writeXmlFooter(writer, xml_root);
         },
     }
 }
@@ -1435,6 +1479,27 @@ fn runColumns(
                 break;
             }
         },
+        .xml => {
+            var stdin_buf: [4096]u8 = undefined;
+            var stdin_file_reader = std.Io.File.reader(std.Io.File.stdin(), io, &stdin_buf);
+
+            const names = xml.getXmlColumnNames(allocator, &stdin_file_reader.interface, stderr_writer);
+            defer {
+                for (names) |name| allocator.free(name);
+                allocator.free(names);
+            }
+            for (names) |name| {
+                if (args.verbose) {
+                    stdout_writer.print("{s} TEXT\n", .{name}) catch |err| {
+                        std.log.err("failed to write output: {}", .{err});
+                    };
+                } else {
+                    stdout_writer.print("{s}\n", .{name}) catch |err| {
+                        std.log.err("failed to write output: {}", .{err});
+                    };
+                }
+            }
+        },
     }
 }
 
@@ -1704,6 +1769,37 @@ fn runValidate(
                 std.process.exit(@intFromEnum(ExitCode.usage));
             };
         },
+        .xml => {
+            var stdin_buf: [4096]u8 = undefined;
+            var stdin_file_reader = std.Io.File.reader(std.Io.File.stdin(), io, &stdin_buf);
+
+            const summary = xml.summarizeXml(allocator, &stdin_file_reader.interface, stderr_writer);
+            defer {
+                for (summary.col_names) |name| allocator.free(name);
+                allocator.free(summary.col_names);
+            }
+
+            var count_buf: [32]u8 = undefined;
+            const count_str = fmtThousands(&count_buf, summary.row_count);
+            stdout_writer.print("OK: {s} rows, {d} columns (", .{ count_str, summary.col_names.len }) catch |err| {
+                std.log.err("failed to write output: {}", .{err});
+                std.process.exit(@intFromEnum(ExitCode.usage));
+            };
+            for (summary.col_names, 0..) |name, i| {
+                if (i > 0) stdout_writer.writeAll(", ") catch |err| {
+                    std.log.err("failed to write output: {}", .{err});
+                    std.process.exit(@intFromEnum(ExitCode.usage));
+                };
+                stdout_writer.print("{s} TEXT", .{name}) catch |err| {
+                    std.log.err("failed to write output: {}", .{err});
+                    std.process.exit(@intFromEnum(ExitCode.usage));
+                };
+            }
+            stdout_writer.writeAll(")\n") catch |err| {
+                std.log.err("failed to write output: {}", .{err});
+                std.process.exit(@intFromEnum(ExitCode.usage));
+            };
+        },
     }
 }
 
@@ -1721,7 +1817,7 @@ fn runSample(
     stdout_writer: *std.Io.Writer,
 ) void {
     switch (args.input_format) {
-        .json, .ndjson => fatal(
+        .json, .ndjson, .xml => fatal(
             "--sample only supports CSV and TSV input; use -I csv (default) or --tsv",
             stderr_writer,
             .usage,
@@ -1894,6 +1990,11 @@ fn run(
             var stdin_reader = std.Io.File.reader(std.Io.File.stdin(), io, &stdin_buf);
             break :blk json.loadNdjsonInput(allocator, &stdin_reader.interface, db, parsed.max_rows, stderr_writer);
         },
+        .xml => blk: {
+            var stdin_buf: [4096]u8 = undefined;
+            var stdin_reader = std.Io.File.reader(std.Io.File.stdin(), io, &stdin_buf);
+            break :blk xml.loadXmlInput(allocator, &stdin_reader.interface, db, parsed.max_rows, stderr_writer);
+        },
     };
 
     // Print row count and elapsed time to stderr when stderr is a TTY or --verbose is set.
@@ -1915,7 +2016,7 @@ fn run(
         stderr_writer.flush() catch |err| std.log.err("failed to flush stderr: {}", .{err});
     }
 
-    execQuery(allocator, db, query, stdout_writer, parsed.header, parsed.output_format) catch {
+    execQuery(allocator, db, query, stdout_writer, parsed.header, parsed.output_format, parsed.xml_root, parsed.xml_row) catch {
         stdout_writer.flush() catch |err| std.log.err("failed to flush output before fatal: {}", .{err});
         fatalSqlWithContext(allocator, db, std.mem.span(c.sqlite3_errmsg(db)), stderr_writer);
     };
@@ -1966,14 +2067,14 @@ pub fn main(init: std.process.Init.Minimal) void {
             },
             error.InvalidInputFormat => {
                 stderr_writer.writeAll(
-                    "error: unknown input format; supported: csv, tsv, json, ndjson\n",
+                    "error: unknown input format; supported: csv, tsv, json, ndjson, xml\n",
                 ) catch |werr| std.log.err("failed to write error message: {}", .{werr});
                 stderr_writer.flush() catch |ferr| std.log.err("failed to flush: {}", .{ferr});
                 std.process.exit(@intFromEnum(ExitCode.usage));
             },
             error.InvalidOutputFormat => {
                 stderr_writer.writeAll(
-                    "error: unknown output format; supported: csv, tsv, json, ndjson\n",
+                    "error: unknown output format; supported: csv, tsv, json, ndjson, xml\n",
                 ) catch |werr| std.log.err("failed to write error message: {}", .{werr});
                 stderr_writer.flush() catch |ferr| std.log.err("failed to flush: {}", .{ferr});
                 std.process.exit(@intFromEnum(ExitCode.usage));

--- a/src/sqlite.zig
+++ b/src/sqlite.zig
@@ -1,0 +1,95 @@
+//! Shared SQLite helper functions used by all input format loaders.
+
+const std = @import("std");
+const c = @import("c");
+
+/// SQLITE_STATIC: caller manages string lifetime; SQLite must not free it.
+pub const sqlite_static: c.sqlite3_destructor_type = null;
+
+// Shared exit codes (same values as in each format module)
+pub const exit_usage: u8 = 1;
+pub const exit_parse: u8 = 2;
+pub const exit_sql: u8 = 3;
+
+/// fatal(fmt, writer, code, args) → noreturn
+///
+/// Writes an error message to writer and exits with the given code.
+pub fn fatal(comptime fmt: []const u8, writer: *std.Io.Writer, code: u8, args: anytype) noreturn {
+    writer.print("error: " ++ fmt ++ "\n", args) catch |err| std.log.err("failed to write error: {}", .{err});
+    writer.flush() catch |err| std.log.err("failed to flush: {}", .{err});
+    std.process.exit(code);
+}
+
+/// Create table `t` with all-TEXT columns. Column names are double-quote–escaped
+/// per SQL identifier rules.
+pub fn createAllTextTable(
+    allocator: std.mem.Allocator,
+    db: *c.sqlite3,
+    cols: []const []const u8,
+    writer: *std.Io.Writer,
+) void {
+    var sql: std.ArrayList(u8) = .empty;
+    defer sql.deinit(allocator);
+
+    sql.appendSlice(allocator, "CREATE TABLE t (") catch fatal("out of memory", writer, exit_parse, .{});
+    for (cols, 0..) |col, i| {
+        if (i > 0) sql.appendSlice(allocator, ", ") catch fatal("out of memory", writer, exit_parse, .{});
+        sql.append(allocator, '"') catch fatal("out of memory", writer, exit_parse, .{});
+        for (col) |ch| {
+            if (ch == '"') sql.append(allocator, '"') catch fatal("out of memory", writer, exit_parse, .{});
+            sql.append(allocator, ch) catch fatal("out of memory", writer, exit_parse, .{});
+        }
+        sql.appendSlice(allocator, "\" TEXT") catch fatal("out of memory", writer, exit_parse, .{});
+    }
+    sql.appendSlice(allocator, ")") catch fatal("out of memory", writer, exit_parse, .{});
+    sql.append(allocator, 0) catch fatal("out of memory", writer, exit_parse, .{});
+
+    var errmsg: [*c]u8 = null;
+    if (c.sqlite3_exec(db, sql.items.ptr, null, null, &errmsg) != c.SQLITE_OK) {
+        const msg = if (errmsg != null) std.mem.span(errmsg) else std.mem.span(c.sqlite3_errmsg(db));
+        if (errmsg != null) c.sqlite3_free(errmsg);
+        fatal("{s}", writer, exit_sql, .{msg});
+    }
+}
+
+/// Prepare `INSERT INTO t VALUES (?, …, ?)` with n parameters.
+pub fn prepareInsertStmt(
+    allocator: std.mem.Allocator,
+    db: *c.sqlite3,
+    n: usize,
+    writer: *std.Io.Writer,
+) *c.sqlite3_stmt {
+    var sql: std.ArrayList(u8) = .empty;
+    defer sql.deinit(allocator);
+
+    sql.appendSlice(allocator, "INSERT INTO t VALUES (") catch fatal("out of memory", writer, exit_parse, .{});
+    for (0..n) |i| {
+        if (i > 0) sql.append(allocator, ',') catch fatal("out of memory", writer, exit_parse, .{});
+        sql.append(allocator, '?') catch fatal("out of memory", writer, exit_parse, .{});
+    }
+    sql.appendSlice(allocator, ")") catch fatal("out of memory", writer, exit_parse, .{});
+    sql.append(allocator, 0) catch fatal("out of memory", writer, exit_parse, .{});
+
+    var stmt: ?*c.sqlite3_stmt = null;
+    if (c.sqlite3_prepare_v2(db, sql.items.ptr, -1, &stmt, null) != c.SQLITE_OK)
+        fatal("{s}", writer, exit_sql, .{std.mem.span(c.sqlite3_errmsg(db))});
+    return stmt.?;
+}
+
+pub fn beginTransaction(db: *c.sqlite3, writer: *std.Io.Writer) void {
+    var errmsg: [*c]u8 = null;
+    if (c.sqlite3_exec(db, "BEGIN TRANSACTION", null, null, &errmsg) != c.SQLITE_OK) {
+        const msg = if (errmsg != null) std.mem.span(errmsg) else std.mem.span(c.sqlite3_errmsg(db));
+        if (errmsg != null) c.sqlite3_free(errmsg);
+        fatal("{s}", writer, exit_sql, .{msg});
+    }
+}
+
+pub fn commitTransaction(db: *c.sqlite3, writer: *std.Io.Writer) void {
+    var errmsg: [*c]u8 = null;
+    if (c.sqlite3_exec(db, "COMMIT", null, null, &errmsg) != c.SQLITE_OK) {
+        const msg = if (errmsg != null) std.mem.span(errmsg) else std.mem.span(c.sqlite3_errmsg(db));
+        if (errmsg != null) c.sqlite3_free(errmsg);
+        fatal("{s}", writer, exit_sql, .{msg});
+    }
+}

--- a/src/xml.zig
+++ b/src/xml.zig
@@ -30,86 +30,17 @@
 const std = @import("std");
 const c = @import("c");
 
-/// SQLITE_STATIC: caller manages string lifetime; SQLite must not free it.
-const sqlite_static: c.sqlite3_destructor_type = null;
+const sqlite_helpers = @import("sqlite.zig");
 
-const exit_usage: u8 = 1;
-const exit_parse: u8 = 2;
-const exit_sql: u8 = 3;
-
-fn fatal(comptime fmt: []const u8, writer: *std.Io.Writer, code: u8, args: anytype) noreturn {
-    writer.print("error: " ++ fmt ++ "\n", args) catch |err| std.log.err("failed to write error: {}", .{err});
-    writer.flush() catch |err| std.log.err("failed to flush: {}", .{err});
-    std.process.exit(code);
-}
-
-fn createAllTextTable(
-    allocator: std.mem.Allocator,
-    db: *c.sqlite3,
-    cols: []const []const u8,
-    writer: *std.Io.Writer,
-) void {
-    var sql: std.ArrayList(u8) = .empty;
-    defer sql.deinit(allocator);
-    sql.appendSlice(allocator, "CREATE TABLE t (") catch fatal("out of memory", writer, exit_parse, .{});
-    for (cols, 0..) |col, i| {
-        if (i > 0) sql.appendSlice(allocator, ", ") catch fatal("out of memory", writer, exit_parse, .{});
-        sql.append(allocator, '"') catch fatal("out of memory", writer, exit_parse, .{});
-        for (col) |ch| {
-            if (ch == '"') sql.append(allocator, '"') catch fatal("out of memory", writer, exit_parse, .{});
-            sql.append(allocator, ch) catch fatal("out of memory", writer, exit_parse, .{});
-        }
-        sql.appendSlice(allocator, "\" TEXT") catch fatal("out of memory", writer, exit_parse, .{});
-    }
-    sql.appendSlice(allocator, ")") catch fatal("out of memory", writer, exit_parse, .{});
-    sql.append(allocator, 0) catch fatal("out of memory", writer, exit_parse, .{});
-    var errmsg: [*c]u8 = null;
-    if (c.sqlite3_exec(db, sql.items.ptr, null, null, &errmsg) != c.SQLITE_OK) {
-        const msg = if (errmsg != null) std.mem.span(errmsg) else std.mem.span(c.sqlite3_errmsg(db));
-        if (errmsg != null) c.sqlite3_free(errmsg);
-        fatal("{s}", writer, exit_sql, .{msg});
-    }
-}
-
-fn prepareInsertStmt(
-    allocator: std.mem.Allocator,
-    db: *c.sqlite3,
-    n: usize,
-    writer: *std.Io.Writer,
-) *c.sqlite3_stmt {
-    var sql: std.ArrayList(u8) = .empty;
-    defer sql.deinit(allocator);
-    sql.appendSlice(allocator, "INSERT INTO t VALUES (") catch fatal("out of memory", writer, exit_parse, .{});
-    for (0..n) |i| {
-        if (i > 0) sql.append(allocator, ',') catch fatal("out of memory", writer, exit_parse, .{});
-        sql.append(allocator, '?') catch fatal("out of memory", writer, exit_parse, .{});
-    }
-    sql.appendSlice(allocator, ")") catch fatal("out of memory", writer, exit_parse, .{});
-    sql.append(allocator, 0) catch fatal("out of memory", writer, exit_parse, .{});
-    var stmt: ?*c.sqlite3_stmt = null;
-    if (c.sqlite3_prepare_v2(db, sql.items.ptr, -1, &stmt, null) != c.SQLITE_OK)
-        fatal("{s}", writer, exit_sql, .{std.mem.span(c.sqlite3_errmsg(db))});
-    return stmt.?;
-}
-
-fn beginTransaction(db: *c.sqlite3, writer: *std.Io.Writer) void {
-    var errmsg: [*c]u8 = null;
-    if (c.sqlite3_exec(db, "BEGIN TRANSACTION", null, null, &errmsg) != c.SQLITE_OK) {
-        const msg = if (errmsg != null) std.mem.span(errmsg) else std.mem.span(c.sqlite3_errmsg(db));
-        if (errmsg != null) c.sqlite3_free(errmsg);
-        fatal("{s}", writer, exit_sql, .{msg});
-    }
-}
-
-fn commitTransaction(db: *c.sqlite3, writer: *std.Io.Writer) void {
-    var errmsg: [*c]u8 = null;
-    if (c.sqlite3_exec(db, "COMMIT", null, null, &errmsg) != c.SQLITE_OK) {
-        const msg = if (errmsg != null) std.mem.span(errmsg) else std.mem.span(c.sqlite3_errmsg(db));
-        if (errmsg != null) c.sqlite3_free(errmsg);
-        fatal("{s}", writer, exit_sql, .{msg});
-    }
-    if (errmsg != null) c.sqlite3_free(errmsg);
-}
+const createAllTextTable = sqlite_helpers.createAllTextTable;
+const prepareInsertStmt = sqlite_helpers.prepareInsertStmt;
+const beginTransaction = sqlite_helpers.beginTransaction;
+const commitTransaction = sqlite_helpers.commitTransaction;
+const fatal = sqlite_helpers.fatal;
+const exit_usage = sqlite_helpers.exit_usage;
+const exit_parse = sqlite_helpers.exit_parse;
+const exit_sql = sqlite_helpers.exit_sql;
+const sqlite_static = sqlite_helpers.sqlite_static;
 
 // ─── XML escaping ─────────────────────────────────────
 
@@ -160,8 +91,36 @@ fn decodeEntities(allocator: std.mem.Allocator, s: []const u8) ![]u8 {
             } else if (std.mem.startsWith(u8, s[i..], "&apos;")) {
                 try out.append(allocator, '\'');
                 i += 6;
+            } else if (std.mem.startsWith(u8, s[i..], "&#")) {
+                // Numeric character reference: &#NNN; (decimal) or &#xNNN; (hex)
+                const ref_start = i;
+                i += 2; // past "&#"
+                const is_hex = i < s.len and (s[i] == 'x' or s[i] == 'X');
+                if (is_hex) i += 1;
+                const digits_start = i;
+                while (i < s.len and s[i] != ';') : (i += 1) {}
+                if (i < s.len and i > digits_start) {
+                    const digits = s[digits_start..i];
+                    i += 1; // past ';'
+                    const codepoint = if (is_hex)
+                        std.fmt.parseInt(u21, digits, 16) catch null
+                    else
+                        std.fmt.parseInt(u21, digits, 10) catch null;
+                    if (codepoint) |cp| {
+                        var utf8_buf: [4]u8 = undefined;
+                        const len = std.unicode.utf8Encode(cp, &utf8_buf) catch {
+                            // Invalid codepoint — pass through as-is
+                            try out.appendSlice(allocator, s[ref_start..i]);
+                            continue;
+                        };
+                        try out.appendSlice(allocator, utf8_buf[0..len]);
+                        continue;
+                    }
+                }
+                // Malformed numeric reference — pass through as-is
+                try out.appendSlice(allocator, s[ref_start..i]);
             } else {
-                // Unknown or numeric entity — pass through as-is
+                // Unknown named entity — pass through as-is
                 try out.append(allocator, s[i]);
                 i += 1;
             }
@@ -369,12 +328,17 @@ pub const XmlParser = struct {
     /// Read an XML name; fatal if the current position is not the start of a name.
     fn readName(self: *XmlParser, err_writer: *std.Io.Writer) []const u8 {
         const start = self.pos;
-        // XML name: letter/'_' first, then letter/digit/'-'/'.'/'_'/':'
+        // XML NameStartChar: letter, '_', ':' (digits not allowed as first char)
+        const first = self.peek() orelse self.fatalAt("expected element name", err_writer, .{});
+        switch (first) {
+            'a'...'z', 'A'...'Z', '_', ':' => self.advance(),
+            else => self.fatalAt("expected element name", err_writer, .{}),
+        }
+        // NameChar: letter, digit, '-', '.', '_', ':'
         while (self.peek()) |ch| switch (ch) {
             'a'...'z', 'A'...'Z', '0'...'9', '-', '.', '_', ':' => self.advance(),
             else => break,
         };
-        if (self.pos == start) self.fatalAt("expected element name", err_writer, .{});
         return self.data[start..self.pos];
     }
 
@@ -813,4 +777,163 @@ pub fn loadXmlInput(
     if (col_names == null) fatal("XML document has no row elements", stderr_writer, exit_parse, .{});
     if (in_transaction) commitTransaction(db, stderr_writer);
     return rows_inserted;
+}
+
+// ─── Unit tests ───────────────────────────────────────
+
+test "decodeEntities: predefined XML entities" {
+    const allocator = std.testing.allocator;
+    const result = try decodeEntities(allocator, "&amp;&lt;&gt;&quot;&apos;");
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("&<>\"'", result);
+}
+
+test "decodeEntities: plain text unchanged" {
+    const allocator = std.testing.allocator;
+    const result = try decodeEntities(allocator, "hello world");
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("hello world", result);
+}
+
+test "decodeEntities: unknown entity passthrough" {
+    const allocator = std.testing.allocator;
+    const result = try decodeEntities(allocator, "&copy;");
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("&copy;", result);
+}
+
+test "decodeEntities: numeric decimal reference" {
+    const allocator = std.testing.allocator;
+    const result = try decodeEntities(allocator, "&#65;"); // 'A'
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("A", result);
+}
+
+test "decodeEntities: numeric hex reference" {
+    const allocator = std.testing.allocator;
+    const result = try decodeEntities(allocator, "&#x41;"); // 'A'
+    defer allocator.free(result);
+    try std.testing.expectEqualStrings("A", result);
+}
+
+test "writeXmlEscaped: escapes special characters" {
+    var buf: [128]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    try writeXmlEscaped(&writer, "a&b<c>d\"e'f");
+    const written = std.Io.Writer.buffered(&writer);
+    try std.testing.expectEqualStrings("a&amp;b&lt;c&gt;d&quot;e&apos;f", written);
+}
+
+test "writeXmlEscaped: plain text unchanged" {
+    var buf: [64]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    try writeXmlEscaped(&writer, "hello world 123");
+    const written = std.Io.Writer.buffered(&writer);
+    try std.testing.expectEqualStrings("hello world 123", written);
+}
+
+test "writeXmlHeader and writeXmlFooter" {
+    var buf: [128]u8 = undefined;
+    var writer: std.Io.Writer = .fixed(&buf);
+    try writeXmlHeader(&writer, "results");
+    try writeXmlFooter(&writer, "results");
+    const written = std.Io.Writer.buffered(&writer);
+    try std.testing.expectEqualStrings(
+        "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<results>\n</results>\n",
+        written,
+    );
+}
+
+test "XmlParser.nextRow: simple row with two columns" {
+    const allocator = std.testing.allocator;
+    var err_buf: [256]u8 = undefined;
+    var err_writer: std.Io.Writer = .fixed(&err_buf);
+
+    const input = "<results><row><name>Alice</name><age>30</age></row></results>";
+    var p = XmlParser.init(input);
+    p.skipPrologue(&err_writer);
+    const root = p.readRootOpen(&err_writer);
+    try std.testing.expectEqualStrings("results", root);
+
+    const cols = try p.nextRow(allocator, root, &err_writer);
+    try std.testing.expect(cols != null);
+    defer {
+        for (cols.?) |col| if (col.value) |v| allocator.free(v);
+        allocator.free(cols.?);
+    }
+    try std.testing.expectEqual(@as(usize, 2), cols.?.len);
+    try std.testing.expectEqualStrings("name", cols.?[0].name);
+    try std.testing.expectEqualStrings("Alice", cols.?[0].value.?);
+    try std.testing.expectEqualStrings("age", cols.?[1].name);
+    try std.testing.expectEqualStrings("30", cols.?[1].value.?);
+
+    // No more rows
+    const next = try p.nextRow(allocator, root, &err_writer);
+    try std.testing.expect(next == null);
+}
+
+test "XmlParser.nextRow: self-closing column is null" {
+    const allocator = std.testing.allocator;
+    var err_buf: [256]u8 = undefined;
+    var err_writer: std.Io.Writer = .fixed(&err_buf);
+
+    const input = "<r><row><name/><age>5</age></row></r>";
+    var p = XmlParser.init(input);
+    p.skipPrologue(&err_writer);
+    const root = p.readRootOpen(&err_writer);
+
+    const cols = try p.nextRow(allocator, root, &err_writer);
+    try std.testing.expect(cols != null);
+    defer {
+        for (cols.?) |col| if (col.value) |v| allocator.free(v);
+        allocator.free(cols.?);
+    }
+    try std.testing.expectEqual(@as(usize, 2), cols.?.len);
+    try std.testing.expectEqualStrings("name", cols.?[0].name);
+    try std.testing.expect(cols.?[0].value == null); // self-closing → null
+    try std.testing.expectEqualStrings("5", cols.?[1].value.?);
+}
+
+test "XmlParser.nextRow: entities decoded in content" {
+    const allocator = std.testing.allocator;
+    var err_buf: [256]u8 = undefined;
+    var err_writer: std.Io.Writer = .fixed(&err_buf);
+
+    const input = "<r><row><val>Alice &amp; Bob &lt;test&gt;</val></row></r>";
+    var p = XmlParser.init(input);
+    p.skipPrologue(&err_writer);
+    const root = p.readRootOpen(&err_writer);
+
+    const cols = try p.nextRow(allocator, root, &err_writer);
+    try std.testing.expect(cols != null);
+    defer {
+        for (cols.?) |col| if (col.value) |v| allocator.free(v);
+        allocator.free(cols.?);
+    }
+    try std.testing.expectEqualStrings("Alice & Bob <test>", cols.?[0].value.?);
+}
+
+test "XmlParser.nextRow: empty document returns null" {
+    const allocator = std.testing.allocator;
+    var err_buf: [256]u8 = undefined;
+    var err_writer: std.Io.Writer = .fixed(&err_buf);
+
+    const input = "<r></r>";
+    var p = XmlParser.init(input);
+    p.skipPrologue(&err_writer);
+    const root = p.readRootOpen(&err_writer);
+
+    const cols = try p.nextRow(allocator, root, &err_writer);
+    try std.testing.expect(cols == null);
+}
+
+test "XmlParser: XML declaration in prologue" {
+    var err_buf: [256]u8 = undefined;
+    var err_writer: std.Io.Writer = .fixed(&err_buf);
+
+    const input = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<results></results>";
+    var p = XmlParser.init(input);
+    p.skipPrologue(&err_writer);
+    const root = p.readRootOpen(&err_writer);
+    try std.testing.expectEqualStrings("results", root);
 }

--- a/src/xml.zig
+++ b/src/xml.zig
@@ -1,0 +1,816 @@
+//! XML row-based I/O — input loading and output formatting.
+//!
+//! Input
+//! ─────
+//!   loadXmlInput      — read row-based XML from stdin, create table `t`, insert rows.
+//!   getXmlColumnNames — parse XML and return column names from the first row.
+//!   summarizeXml      — parse XML, count rows, return column names (for --validate).
+//!
+//! Output
+//! ──────
+//!   writeXmlHeader  — emit the XML declaration and opening root element.
+//!   writeXmlRow     — emit one SQLite result row as a compact XML row element.
+//!   writeXmlFooter  — emit the closing root element.
+//!
+//! XML format (output)
+//! ───────────────────
+//!   <?xml version="1.0" encoding="UTF-8"?>
+//!   <results>
+//!   <row><name>Alice</name><age>30</age></row>
+//!   </results>
+//!
+//! XML format (input)
+//! ──────────────────
+//!   Row-based only: each direct child of the root element is a row.
+//!   Each child of a row element is a column (element name = column name,
+//!   text content = value). Nested elements inside a column are captured as
+//!   raw XML strings. Supported entities: &amp; &lt; &gt; &quot; &apos;
+//!   CDATA sections are preserved as raw markup.
+
+const std = @import("std");
+const c = @import("c");
+
+/// SQLITE_STATIC: caller manages string lifetime; SQLite must not free it.
+const sqlite_static: c.sqlite3_destructor_type = null;
+
+const exit_usage: u8 = 1;
+const exit_parse: u8 = 2;
+const exit_sql: u8 = 3;
+
+fn fatal(comptime fmt: []const u8, writer: *std.Io.Writer, code: u8, args: anytype) noreturn {
+    writer.print("error: " ++ fmt ++ "\n", args) catch |err| std.log.err("failed to write error: {}", .{err});
+    writer.flush() catch |err| std.log.err("failed to flush: {}", .{err});
+    std.process.exit(code);
+}
+
+fn createAllTextTable(
+    allocator: std.mem.Allocator,
+    db: *c.sqlite3,
+    cols: []const []const u8,
+    writer: *std.Io.Writer,
+) void {
+    var sql: std.ArrayList(u8) = .empty;
+    defer sql.deinit(allocator);
+    sql.appendSlice(allocator, "CREATE TABLE t (") catch fatal("out of memory", writer, exit_parse, .{});
+    for (cols, 0..) |col, i| {
+        if (i > 0) sql.appendSlice(allocator, ", ") catch fatal("out of memory", writer, exit_parse, .{});
+        sql.append(allocator, '"') catch fatal("out of memory", writer, exit_parse, .{});
+        for (col) |ch| {
+            if (ch == '"') sql.append(allocator, '"') catch fatal("out of memory", writer, exit_parse, .{});
+            sql.append(allocator, ch) catch fatal("out of memory", writer, exit_parse, .{});
+        }
+        sql.appendSlice(allocator, "\" TEXT") catch fatal("out of memory", writer, exit_parse, .{});
+    }
+    sql.appendSlice(allocator, ")") catch fatal("out of memory", writer, exit_parse, .{});
+    sql.append(allocator, 0) catch fatal("out of memory", writer, exit_parse, .{});
+    var errmsg: [*c]u8 = null;
+    if (c.sqlite3_exec(db, sql.items.ptr, null, null, &errmsg) != c.SQLITE_OK) {
+        const msg = if (errmsg != null) std.mem.span(errmsg) else std.mem.span(c.sqlite3_errmsg(db));
+        if (errmsg != null) c.sqlite3_free(errmsg);
+        fatal("{s}", writer, exit_sql, .{msg});
+    }
+}
+
+fn prepareInsertStmt(
+    allocator: std.mem.Allocator,
+    db: *c.sqlite3,
+    n: usize,
+    writer: *std.Io.Writer,
+) *c.sqlite3_stmt {
+    var sql: std.ArrayList(u8) = .empty;
+    defer sql.deinit(allocator);
+    sql.appendSlice(allocator, "INSERT INTO t VALUES (") catch fatal("out of memory", writer, exit_parse, .{});
+    for (0..n) |i| {
+        if (i > 0) sql.append(allocator, ',') catch fatal("out of memory", writer, exit_parse, .{});
+        sql.append(allocator, '?') catch fatal("out of memory", writer, exit_parse, .{});
+    }
+    sql.appendSlice(allocator, ")") catch fatal("out of memory", writer, exit_parse, .{});
+    sql.append(allocator, 0) catch fatal("out of memory", writer, exit_parse, .{});
+    var stmt: ?*c.sqlite3_stmt = null;
+    if (c.sqlite3_prepare_v2(db, sql.items.ptr, -1, &stmt, null) != c.SQLITE_OK)
+        fatal("{s}", writer, exit_sql, .{std.mem.span(c.sqlite3_errmsg(db))});
+    return stmt.?;
+}
+
+fn beginTransaction(db: *c.sqlite3, writer: *std.Io.Writer) void {
+    var errmsg: [*c]u8 = null;
+    if (c.sqlite3_exec(db, "BEGIN TRANSACTION", null, null, &errmsg) != c.SQLITE_OK) {
+        const msg = if (errmsg != null) std.mem.span(errmsg) else std.mem.span(c.sqlite3_errmsg(db));
+        if (errmsg != null) c.sqlite3_free(errmsg);
+        fatal("{s}", writer, exit_sql, .{msg});
+    }
+}
+
+fn commitTransaction(db: *c.sqlite3, writer: *std.Io.Writer) void {
+    var errmsg: [*c]u8 = null;
+    if (c.sqlite3_exec(db, "COMMIT", null, null, &errmsg) != c.SQLITE_OK) {
+        const msg = if (errmsg != null) std.mem.span(errmsg) else std.mem.span(c.sqlite3_errmsg(db));
+        if (errmsg != null) c.sqlite3_free(errmsg);
+        fatal("{s}", writer, exit_sql, .{msg});
+    }
+    if (errmsg != null) c.sqlite3_free(errmsg);
+}
+
+// ─── XML escaping ─────────────────────────────────────
+
+/// writeXmlEscaped(writer, s) → !void
+///
+/// Pre:  s is a valid UTF-8 slice
+/// Post: s is emitted to writer with XML character entity escaping:
+///       '&' → "&amp;", '<' → "&lt;", '>' → "&gt;",
+///       '"' → "&quot;", '\'' → "&apos;"
+pub fn writeXmlEscaped(writer: *std.Io.Writer, s: []const u8) !void {
+    for (s) |ch| {
+        switch (ch) {
+            '&' => try writer.writeAll("&amp;"),
+            '<' => try writer.writeAll("&lt;"),
+            '>' => try writer.writeAll("&gt;"),
+            '"' => try writer.writeAll("&quot;"),
+            '\'' => try writer.writeAll("&apos;"),
+            else => try writer.writeByte(ch),
+        }
+    }
+}
+
+/// decodeEntities(allocator, s) → ![]u8
+///
+/// Pre:  s is a valid UTF-8 slice, possibly containing XML entity references
+/// Post: &amp;→&, &lt;→<, &gt;→>, &quot;→", &apos;→'
+///       Returns a newly allocated slice; caller must free.
+fn decodeEntities(allocator: std.mem.Allocator, s: []const u8) ![]u8 {
+    var out: std.ArrayList(u8) = .empty;
+    errdefer out.deinit(allocator);
+    var i: usize = 0;
+    // Loop invariant: out contains the decoded prefix of s[0..i]
+    // Bounding function: s.len - i
+    while (i < s.len) {
+        if (s[i] == '&') {
+            if (std.mem.startsWith(u8, s[i..], "&amp;")) {
+                try out.append(allocator, '&');
+                i += 5;
+            } else if (std.mem.startsWith(u8, s[i..], "&lt;")) {
+                try out.append(allocator, '<');
+                i += 4;
+            } else if (std.mem.startsWith(u8, s[i..], "&gt;")) {
+                try out.append(allocator, '>');
+                i += 4;
+            } else if (std.mem.startsWith(u8, s[i..], "&quot;")) {
+                try out.append(allocator, '"');
+                i += 6;
+            } else if (std.mem.startsWith(u8, s[i..], "&apos;")) {
+                try out.append(allocator, '\'');
+                i += 6;
+            } else {
+                // Unknown or numeric entity — pass through as-is
+                try out.append(allocator, s[i]);
+                i += 1;
+            }
+        } else {
+            try out.append(allocator, s[i]);
+            i += 1;
+        }
+    }
+    return out.toOwnedSlice(allocator);
+}
+
+// ─── Output formatting ────────────────────────────────
+
+/// writeXmlHeader(writer, root_name) → !void
+///
+/// Pre:  root_name is a valid XML element name
+/// Post: XML declaration and opening root element written:
+///       <?xml version="1.0" encoding="UTF-8"?>\n<root_name>\n
+pub fn writeXmlHeader(writer: *std.Io.Writer, root_name: []const u8) !void {
+    try writer.writeAll("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    try writer.writeByte('<');
+    try writer.writeAll(root_name);
+    try writer.writeAll(">\n");
+}
+
+/// writeXmlRow(stmt, col_count, col_names, writer, row_name) → !void
+///
+/// Pre:  sqlite3_step returned SQLITE_ROW for stmt
+///       col_count = sqlite3_column_count(stmt) > 0
+///       col_names.len ≥ col_count; row_name is a valid XML element name
+/// Post: compact row written: <row_name><col>value</col>...</row_name>\n
+///       NULL → empty element body; all text values are XML-escaped
+pub fn writeXmlRow(
+    stmt: *c.sqlite3_stmt,
+    col_count: c_int,
+    col_names: []const [*:0]const u8,
+    writer: *std.Io.Writer,
+    row_name: []const u8,
+) !void {
+    try writer.writeByte('<');
+    try writer.writeAll(row_name);
+    try writer.writeByte('>');
+    // Loop invariant I: columns 0..i-1 have been written
+    // Bounding function: col_count - i
+    var i: c_int = 0;
+    while (i < col_count) : (i += 1) {
+        const name = std.mem.span(col_names[@intCast(i)]);
+        try writer.writeByte('<');
+        try writer.writeAll(name);
+        try writer.writeByte('>');
+        switch (c.sqlite3_column_type(stmt, i)) {
+            c.SQLITE_NULL => {},
+            c.SQLITE_INTEGER => try writer.print("{d}", .{c.sqlite3_column_int64(stmt, i)}),
+            c.SQLITE_FLOAT => {
+                const f = c.sqlite3_column_double(stmt, i);
+                if (f == @trunc(f) and !std.math.isInf(f) and !std.math.isNan(f)) {
+                    try writer.print("{d}", .{@as(i64, @intFromFloat(f))});
+                } else {
+                    try writer.print("{d}", .{f});
+                }
+            },
+            else => {
+                const ptr = c.sqlite3_column_text(stmt, i);
+                if (ptr != null) {
+                    try writeXmlEscaped(writer, std.mem.span(@as([*:0]const u8, @ptrCast(ptr))));
+                }
+            },
+        }
+        try writer.writeAll("</");
+        try writer.writeAll(name);
+        try writer.writeByte('>');
+    }
+    try writer.writeAll("</");
+    try writer.writeAll(row_name);
+    try writer.writeAll(">\n");
+}
+
+/// writeXmlFooter(writer, root_name) → !void
+///
+/// Pre:  root_name is a valid XML element name
+/// Post: closing root element written: </root_name>\n
+pub fn writeXmlFooter(writer: *std.Io.Writer, root_name: []const u8) !void {
+    try writer.writeAll("</");
+    try writer.writeAll(root_name);
+    try writer.writeAll(">\n");
+}
+
+// ─── XML Parser ───────────────────────────────────────
+
+/// Minimal row-based XML parser with line/column error reporting.
+///
+/// Supported constructs:
+///   XML declaration, comments, processing instructions (all skipped in prologue)
+///   Root element with arbitrary attributes
+///   Row elements (direct children of root) with arbitrary attributes
+///   Column elements: text content (entities decoded) or nested elements (raw XML)
+///   CDATA sections (treated as raw content markup)
+///
+/// Usage:
+///   var p = XmlParser.init(data);
+///   p.skipPrologue(err_writer);
+///   const root = p.readRootOpen(err_writer);
+///   while (try p.nextRow(allocator, root, err_writer)) |cols| {
+///       defer { for (cols) |col| { if (col.value) |v| allocator.free(v); } allocator.free(cols); }
+///       // use cols[i].name and cols[i].value
+///   }
+pub const XmlParser = struct {
+    data: []const u8,
+    pos: usize,
+    line: usize,
+    col: usize,
+
+    /// A single column extracted from a row element.
+    pub const Column = struct {
+        /// Element name — a slice of the parser's data buffer (not allocated).
+        name: []const u8,
+        /// Decoded text content, or raw XML for mixed/nested content.
+        /// Null for self-closing elements (<tag/>). Owned: free with allocator.
+        value: ?[]u8,
+    };
+
+    pub fn init(data: []const u8) XmlParser {
+        return .{ .data = data, .pos = 0, .line = 1, .col = 1 };
+    }
+
+    // ─── Primitives ──────────────────────────────────────
+
+    fn peek(self: *const XmlParser) ?u8 {
+        return if (self.pos < self.data.len) self.data[self.pos] else null;
+    }
+
+    fn advance(self: *XmlParser) void {
+        if (self.pos >= self.data.len) return;
+        if (self.data[self.pos] == '\n') {
+            self.line += 1;
+            self.col = 1;
+        } else {
+            self.col += 1;
+        }
+        self.pos += 1;
+    }
+
+    fn skipWs(self: *XmlParser) void {
+        while (self.peek()) |ch| switch (ch) {
+            ' ', '\t', '\r', '\n' => self.advance(),
+            else => break,
+        };
+    }
+
+    fn startsWith(self: *const XmlParser, s: []const u8) bool {
+        return self.pos + s.len <= self.data.len and
+            std.mem.eql(u8, self.data[self.pos .. self.pos + s.len], s);
+    }
+
+    fn fatalAt(self: *const XmlParser, comptime fmt: []const u8, err_writer: *std.Io.Writer, args: anytype) noreturn {
+        err_writer.print("error: xml: line {d}, col {d}: ", .{ self.line, self.col }) catch |err| std.log.err("failed to write error: {}", .{err});
+        err_writer.print(fmt ++ "\n", args) catch |err| std.log.err("failed to write error: {}", .{err});
+        err_writer.flush() catch |err| std.log.err("failed to flush: {}", .{err});
+        std.process.exit(exit_parse);
+    }
+
+    // ─── Skip helpers ────────────────────────────────────
+
+    /// Advance past the first occurrence of `delim`; fatal if not found.
+    fn skipUntilStr(self: *XmlParser, comptime delim: []const u8, err_writer: *std.Io.Writer) void {
+        while (self.pos + delim.len <= self.data.len) {
+            if (std.mem.eql(u8, self.data[self.pos .. self.pos + delim.len], delim)) {
+                for (delim) |_| self.advance();
+                return;
+            }
+            self.advance();
+        }
+        self.fatalAt("unexpected end of input looking for '{s}'", err_writer, .{delim});
+    }
+
+    fn skipComment(self: *XmlParser, err_writer: *std.Io.Writer) void {
+        // Pre: positioned at "<!--"
+        self.advance();
+        self.advance();
+        self.advance();
+        self.advance(); // past "<!--"
+        self.skipUntilStr("-->", err_writer);
+    }
+
+    fn skipProcessingInstruction(self: *XmlParser, err_writer: *std.Io.Writer) void {
+        // Pre: positioned at "<?"
+        self.advance();
+        self.advance(); // past "<?"
+        self.skipUntilStr("?>", err_writer);
+    }
+
+    fn skipWsAndMisc(self: *XmlParser, err_writer: *std.Io.Writer) void {
+        // Loop invariant: all whitespace and misc nodes before self.pos have been consumed
+        // Bounding function: self.data.len - self.pos
+        while (true) {
+            self.skipWs();
+            if (self.startsWith("<!--")) self.skipComment(err_writer)
+            else if (self.startsWith("<?")) self.skipProcessingInstruction(err_writer)
+            else break;
+        }
+    }
+
+    // ─── Name reading ────────────────────────────────────
+
+    /// Read an XML name; fatal if the current position is not the start of a name.
+    fn readName(self: *XmlParser, err_writer: *std.Io.Writer) []const u8 {
+        const start = self.pos;
+        // XML name: letter/'_' first, then letter/digit/'-'/'.'/'_'/':'
+        while (self.peek()) |ch| switch (ch) {
+            'a'...'z', 'A'...'Z', '0'...'9', '-', '.', '_', ':' => self.advance(),
+            else => break,
+        };
+        if (self.pos == start) self.fatalAt("expected element name", err_writer, .{});
+        return self.data[start..self.pos];
+    }
+
+    // ─── Tag close ───────────────────────────────────────
+
+    /// Skip attributes and close the tag.  Returns true when self-closing (`/>`).
+    fn skipAttrsClose(self: *XmlParser, err_writer: *std.Io.Writer) bool {
+        // Loop invariant: all attribute tokens before self.pos consumed
+        // Bounding function: distance to '>' or '/>'
+        while (true) {
+            if (self.peek() == null) self.fatalAt("unexpected end of input in tag", err_writer, .{});
+            const ch = self.peek().?;
+            if (ch == '>') {
+                self.advance();
+                return false;
+            }
+            if (ch == '/' and self.pos + 1 < self.data.len and self.data[self.pos + 1] == '>') {
+                self.advance();
+                self.advance();
+                return true;
+            }
+            if (ch == '"') {
+                self.advance();
+                while (self.peek() != null and self.peek().? != '"') self.advance();
+                if (self.peek() == null) self.fatalAt("unterminated attribute value", err_writer, .{});
+                self.advance(); // closing '"'
+            } else if (ch == '\'') {
+                self.advance();
+                while (self.peek() != null and self.peek().? != '\'') self.advance();
+                if (self.peek() == null) self.fatalAt("unterminated attribute value", err_writer, .{});
+                self.advance(); // closing '\''
+            } else {
+                self.advance();
+            }
+        }
+    }
+
+    // ─── Content reading ─────────────────────────────────
+
+    /// Read element content (text and/or nested elements) until the matching close tag.
+    ///
+    /// Pre:  positioned just after the element's opening tag '>'
+    ///       elem_name is the element whose content we are reading
+    /// Post: returns an owned allocated slice (caller frees):
+    ///         pure text → entities decoded (& < > " ')
+    ///         mixed/nested content → raw XML substring (no entity decoding)
+    ///       position is just after the closing '</elem_name>'
+    fn readContent(
+        self: *XmlParser,
+        allocator: std.mem.Allocator,
+        err_writer: *std.Io.Writer,
+        elem_name: []const u8,
+    ) ![]u8 {
+        const start = self.pos;
+        var depth: usize = 0;
+        var has_nested = false;
+
+        // Loop invariant: depth = number of unclosed nested elements
+        // Bounding function: self.data.len - self.pos (finite input)
+        while (self.pos < self.data.len) {
+            if (self.peek().? != '<') {
+                self.advance();
+                continue;
+            }
+            if (self.startsWith("<!--")) {
+                has_nested = true;
+                self.skipComment(err_writer);
+            } else if (self.startsWith("<![CDATA[")) {
+                has_nested = true;
+                for ("<![CDATA[") |_| self.advance();
+                self.skipUntilStr("]]>", err_writer);
+            } else if (self.startsWith("<?")) {
+                self.skipProcessingInstruction(err_writer);
+            } else if (self.startsWith("</")) {
+                if (depth == 0) {
+                    // This is our closing tag
+                    const content_end = self.pos;
+                    self.advance();
+                    self.advance(); // "</"
+                    self.skipWs();
+                    const close_name = self.readName(err_writer);
+                    self.skipWs();
+                    if (self.peek() != '>') self.fatalAt("expected '>' after closing tag name", err_writer, .{});
+                    self.advance();
+                    if (!std.mem.eql(u8, close_name, elem_name))
+                        self.fatalAt("expected '</{s}>' but found '</{s}>'", err_writer, .{ elem_name, close_name });
+                    const raw = self.data[start..content_end];
+                    // Pure text → decode entities; mixed/nested → keep as raw XML
+                    if (!has_nested) return decodeEntities(allocator, raw);
+                    return allocator.dupe(u8, raw);
+                }
+                // Closing tag of a nested element
+                depth -= 1;
+                self.advance();
+                self.advance(); // "</"
+                _ = self.readName(err_writer);
+                self.skipWs();
+                if (self.peek() == '>') self.advance();
+            } else {
+                // Opening tag of a nested element
+                has_nested = true;
+                self.advance(); // '<'
+                _ = self.readName(err_writer);
+                const self_closing = self.skipAttrsClose(err_writer);
+                if (!self_closing) depth += 1;
+            }
+        }
+        self.fatalAt("unexpected end of input: unclosed element '{s}'", err_writer, .{elem_name});
+    }
+
+    // ─── High-level API ──────────────────────────────────
+
+    /// Skip the XML prologue: declaration, processing instructions, comments.
+    pub fn skipPrologue(self: *XmlParser, err_writer: *std.Io.Writer) void {
+        self.skipWs();
+        if (self.startsWith("<?")) self.skipProcessingInstruction(err_writer);
+        self.skipWsAndMisc(err_writer);
+    }
+
+    /// Expect and consume the root element's opening tag.
+    /// Returns the root element name (a slice of the parser's data buffer).
+    /// Fatal if the input doesn't start with '<' or if the element is self-closing.
+    pub fn readRootOpen(self: *XmlParser, err_writer: *std.Io.Writer) []const u8 {
+        if (self.peek() != '<') self.fatalAt("expected '<' to start root element", err_writer, .{});
+        self.advance(); // '<'
+        const name = self.readName(err_writer);
+        const self_closing = self.skipAttrsClose(err_writer);
+        if (self_closing) self.fatalAt("root element is self-closing (no rows possible)", err_writer, .{});
+        return name;
+    }
+
+    /// Read the next row element from the XML stream.
+    ///
+    /// Pre:  positioned after the root opening tag (or a previous row's closing tag)
+    /// Post: returns null when the root closing tag is reached (no more rows)
+    ///       returns an owned slice of Column structs for the next row
+    ///       caller must free each col.value (when non-null) and the slice itself
+    pub fn nextRow(
+        self: *XmlParser,
+        allocator: std.mem.Allocator,
+        root_name: []const u8,
+        err_writer: *std.Io.Writer,
+    ) !?[]Column {
+        self.skipWsAndMisc(err_writer);
+        if (self.peek() == null)
+            self.fatalAt("unexpected end of input: missing '</{s}>'", err_writer, .{root_name});
+
+        // Root closing tag → end of rows
+        if (self.startsWith("</")) {
+            self.advance();
+            self.advance(); // "</"
+            self.skipWs();
+            const close_name = self.readName(err_writer);
+            if (!std.mem.eql(u8, close_name, root_name))
+                self.fatalAt("expected '</{s}>' but found '</{s}>'", err_writer, .{ root_name, close_name });
+            self.skipWs();
+            if (self.peek() == '>') self.advance();
+            return null;
+        }
+
+        // Row opening tag
+        if (self.peek() != '<') self.fatalAt("expected '<' to start row element", err_writer, .{});
+        self.advance(); // '<'
+        const row_tag = self.readName(err_writer);
+        const row_self_close = self.skipAttrsClose(err_writer);
+
+        var cols: std.ArrayList(Column) = .empty;
+        errdefer {
+            for (cols.items) |col| if (col.value) |v| allocator.free(v);
+            cols.deinit(allocator);
+        }
+
+        if (!row_self_close) {
+            // Loop invariant: cols contains all column elements of this row parsed so far
+            // Bounding function: distance to row closing tag
+            while (true) {
+                self.skipWsAndMisc(err_writer);
+                if (self.peek() == null)
+                    self.fatalAt("unexpected end of input in row element", err_writer, .{});
+
+                // Row closing tag
+                if (self.startsWith("</")) {
+                    self.advance();
+                    self.advance(); // "</"
+                    self.skipWs();
+                    const close_row = self.readName(err_writer);
+                    if (!std.mem.eql(u8, close_row, row_tag))
+                        self.fatalAt("expected '</{s}>' but found '</{s}>'", err_writer, .{ row_tag, close_row });
+                    self.skipWs();
+                    if (self.peek() == '>') self.advance();
+                    break;
+                }
+
+                // Column opening tag
+                if (self.peek() != '<')
+                    self.fatalAt("expected '<' to start column element", err_writer, .{});
+                self.advance(); // '<'
+                const col_tag = self.readName(err_writer);
+                const col_self_close = self.skipAttrsClose(err_writer);
+
+                const value: ?[]u8 = if (col_self_close)
+                    null
+                else
+                    try self.readContent(allocator, err_writer, col_tag);
+
+                try cols.append(allocator, .{ .name = col_tag, .value = value });
+            }
+        }
+
+        const owned = try cols.toOwnedSlice(allocator);
+        return owned;
+    }
+};
+
+// ─── Public input functions ───────────────────────────
+
+/// getXmlColumnNames(allocator, reader, stderr_writer) → [][]const u8
+///
+/// Pre:  reader is positioned at the start of a row-based XML document
+/// Post: returns an allocated slice of column names (from the first row);
+///       caller must free each name and the slice
+///       aborts on any parse or I/O error
+pub fn getXmlColumnNames(
+    allocator: std.mem.Allocator,
+    reader: *std.Io.Reader,
+    stderr_writer: *std.Io.Writer,
+) [][]const u8 {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(allocator);
+    while (true) {
+        const byte = reader.takeByte() catch |err| switch (err) {
+            error.EndOfStream => break,
+            error.ReadFailed => fatal("failed to read XML input", stderr_writer, exit_parse, .{}),
+        };
+        buf.append(allocator, byte) catch fatal("out of memory reading XML", stderr_writer, exit_parse, .{});
+    }
+    if (buf.items.len == 0) fatal("empty input", stderr_writer, exit_parse, .{});
+
+    var p = XmlParser.init(buf.items);
+    p.skipPrologue(stderr_writer);
+    const root = p.readRootOpen(stderr_writer);
+
+    const cols = p.nextRow(allocator, root, stderr_writer) catch
+        fatal("out of memory parsing XML", stderr_writer, exit_parse, .{});
+    if (cols == null) fatal("XML document has no row elements", stderr_writer, exit_parse, .{});
+    defer {
+        for (cols.?) |col| if (col.value) |v| allocator.free(v);
+        allocator.free(cols.?);
+    }
+
+    var names: std.ArrayList([]const u8) = .empty;
+    for (cols.?) |col| {
+        const owned = allocator.dupe(u8, col.name) catch
+            fatal("out of memory", stderr_writer, exit_parse, .{});
+        names.append(allocator, owned) catch fatal("out of memory", stderr_writer, exit_parse, .{});
+    }
+    return names.toOwnedSlice(allocator) catch fatal("out of memory", stderr_writer, exit_parse, .{});
+}
+
+/// XmlSummary — result of summarizeXml.
+pub const XmlSummary = struct {
+    /// Total row element count.
+    row_count: usize,
+    /// Column names from the first row; all are reported as TEXT.
+    /// Owned: caller must free each name and the slice.
+    col_names: [][]const u8,
+};
+
+/// summarizeXml(allocator, reader, stderr_writer) → XmlSummary
+///
+/// Pre:  reader is positioned at the start of a row-based XML document
+/// Post: parses the entire document; returns row count and column names
+///       aborts on any parse or I/O error
+pub fn summarizeXml(
+    allocator: std.mem.Allocator,
+    reader: *std.Io.Reader,
+    stderr_writer: *std.Io.Writer,
+) XmlSummary {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(allocator);
+    while (true) {
+        const byte = reader.takeByte() catch |err| switch (err) {
+            error.EndOfStream => break,
+            error.ReadFailed => fatal("failed to read XML input", stderr_writer, exit_parse, .{}),
+        };
+        buf.append(allocator, byte) catch fatal("out of memory reading XML", stderr_writer, exit_parse, .{});
+    }
+    if (buf.items.len == 0) fatal("empty input", stderr_writer, exit_parse, .{});
+
+    var p = XmlParser.init(buf.items);
+    p.skipPrologue(stderr_writer);
+    const root = p.readRootOpen(stderr_writer);
+
+    var row_count: usize = 0;
+    var col_names: ?[][]const u8 = null;
+
+    // Loop invariant: row_count = rows processed so far; col_names set after first row
+    // Bounding function: rows remaining in the XML document (finite)
+    while (true) {
+        const cols = p.nextRow(allocator, root, stderr_writer) catch
+            fatal("out of memory parsing XML", stderr_writer, exit_parse, .{});
+        if (cols == null) break;
+        defer {
+            for (cols.?) |col| if (col.value) |v| allocator.free(v);
+            allocator.free(cols.?);
+        }
+        row_count += 1;
+        if (col_names == null) {
+            var names: std.ArrayList([]const u8) = .empty;
+            for (cols.?) |col| {
+                const owned = allocator.dupe(u8, col.name) catch
+                    fatal("out of memory", stderr_writer, exit_parse, .{});
+                names.append(allocator, owned) catch fatal("out of memory", stderr_writer, exit_parse, .{});
+            }
+            col_names = names.toOwnedSlice(allocator) catch
+                fatal("out of memory", stderr_writer, exit_parse, .{});
+        }
+    }
+
+    if (col_names == null) fatal("XML document has no row elements", stderr_writer, exit_parse, .{});
+    return .{ .row_count = row_count, .col_names = col_names.? };
+}
+
+/// loadXmlInput(allocator, reader, db, max_rows, stderr_writer) → usize
+///
+/// Pre:  reader is positioned at the start of a row-based XML document
+///       db is an open, empty SQLite database
+/// Post: table `t` is created with TEXT columns from the first row's element names;
+///       all row elements are inserted; transaction is committed
+///       result = number of rows inserted
+///       aborts the process on any parse, I/O, or SQL error
+pub fn loadXmlInput(
+    allocator: std.mem.Allocator,
+    reader: *std.Io.Reader,
+    db: *c.sqlite3,
+    max_rows: ?usize,
+    stderr_writer: *std.Io.Writer,
+) usize {
+    var buf: std.ArrayList(u8) = .empty;
+    defer buf.deinit(allocator);
+    while (true) {
+        const byte = reader.takeByte() catch |err| switch (err) {
+            error.EndOfStream => break,
+            error.ReadFailed => fatal("failed to read XML input", stderr_writer, exit_parse, .{}),
+        };
+        buf.append(allocator, byte) catch fatal("out of memory reading XML input", stderr_writer, exit_parse, .{});
+    }
+    if (buf.items.len == 0) fatal("empty input", stderr_writer, exit_parse, .{});
+
+    var p = XmlParser.init(buf.items);
+    p.skipPrologue(stderr_writer);
+    const root_name = p.readRootOpen(stderr_writer);
+
+    // Column names determined from the first row; kept for schema consistency
+    var col_names: ?[][]const u8 = null;
+    defer if (col_names) |names| {
+        for (names) |n| allocator.free(n);
+        allocator.free(names);
+    };
+
+    var insert_stmt: ?*c.sqlite3_stmt = null;
+    defer if (insert_stmt) |s| {
+        _ = c.sqlite3_finalize(s);
+    };
+
+    var rows_inserted: usize = 0;
+    var in_transaction = false;
+
+    // Loop invariant: rows_inserted = rows inserted so far;
+    //   col_names and insert_stmt are set after the first row is processed;
+    //   in_transaction = true after the first insert
+    // Bounding function: row elements remaining in the document (finite)
+    while (true) {
+        const cols = p.nextRow(allocator, root_name, stderr_writer) catch
+            fatal("out of memory parsing XML", stderr_writer, exit_parse, .{});
+        if (cols == null) break;
+
+        defer {
+            for (cols.?) |col| if (col.value) |v| allocator.free(v);
+            allocator.free(cols.?);
+        }
+
+        rows_inserted += 1;
+        if (max_rows) |limit| {
+            if (rows_inserted > limit)
+                fatal("input exceeds --max-rows limit ({d} rows)", stderr_writer, exit_usage, .{limit});
+        }
+
+        if (col_names == null) {
+            // First row: extract schema, create table, begin transaction
+            var names: std.ArrayList([]const u8) = .empty;
+            for (cols.?) |col| {
+                const owned = allocator.dupe(u8, col.name) catch
+                    fatal("out of memory", stderr_writer, exit_parse, .{});
+                names.append(allocator, owned) catch fatal("out of memory", stderr_writer, exit_parse, .{});
+            }
+            if (names.items.len == 0)
+                fatal("first XML row element has no column children", stderr_writer, exit_parse, .{});
+            col_names = names.toOwnedSlice(allocator) catch fatal("out of memory", stderr_writer, exit_parse, .{});
+
+            createAllTextTable(allocator, db, col_names.?, stderr_writer);
+            beginTransaction(db, stderr_writer);
+            in_transaction = true;
+            insert_stmt = prepareInsertStmt(allocator, db, col_names.?.len, stderr_writer);
+        }
+
+        // Bind column values by name (order in row may differ from schema order)
+        const stmt = insert_stmt.?;
+        _ = c.sqlite3_reset(stmt);
+        _ = c.sqlite3_clear_bindings(stmt);
+
+        // Loop invariant: params 1..j bound for col_names[0..j-1]
+        // Bounding function: col_names.?.len - j
+        for (col_names.?, 0..) |col_name, j| {
+            const param_idx: c_int = @intCast(j + 1);
+            // Find this column's value in the current row (linear search; n is small)
+            const value: ?[]u8 = blk: {
+                for (cols.?) |col| {
+                    if (std.mem.eql(u8, col.name, col_name)) break :blk col.value;
+                }
+                break :blk null; // column absent in this row → NULL
+            };
+            if (value) |v| {
+                if (c.sqlite3_bind_text(stmt, param_idx, v.ptr, @intCast(v.len), sqlite_static) != c.SQLITE_OK)
+                    fatal("{s}", stderr_writer, exit_sql, .{std.mem.span(c.sqlite3_errmsg(db))});
+            } else {
+                if (c.sqlite3_bind_null(stmt, param_idx) != c.SQLITE_OK)
+                    fatal("{s}", stderr_writer, exit_sql, .{std.mem.span(c.sqlite3_errmsg(db))});
+            }
+        }
+
+        if (c.sqlite3_step(stmt) != c.SQLITE_DONE)
+            fatal("{s}", stderr_writer, exit_sql, .{std.mem.span(c.sqlite3_errmsg(db))});
+    }
+
+    if (col_names == null) fatal("XML document has no row elements", stderr_writer, exit_parse, .{});
+    if (in_transaction) commitTransaction(db, stderr_writer);
+    return rows_inserted;
+}


### PR DESCRIPTION
## Summary

- Adds `xml` as a supported input and output format (`-I xml` / `-O xml`)
- New `src/xml.zig`: hand-written row-based XML parser and writer (no external XML library)
- New flags `--xml-root` and `--xml-row` to customise root/row element names (defaults: `results` / `row`)
- XML supported in `--columns`, `--validate`; rejected with a clear error in `--sample`

## Format

**Output** (`-O xml`):
```xml
<?xml version="1.0" encoding="UTF-8"?>
<results>
<row><name>Alice</name><age>30</age></row>
</results>
```

**Input** (`-I xml`): row-based XML where each direct child of the root element is a row and each child of a row element is a column. Entities decoded (`&amp;` `&lt;` `&gt;` `&quot;` `&apos;`). Nested elements captured as raw XML strings.

## Changes

- `src/xml.zig` (new): `writeXmlHeader`, `writeXmlRow`, `writeXmlFooter`, `XmlParser`, `loadXmlInput`, `getXmlColumnNames`, `summarizeXml`
- `src/main.zig`: `xml` added to `InputFormat`/`OutputFormat` enums; `--xml-root`/`--xml-row` flag parsing; dispatch in `run()`, `runColumns()`, `runValidate()`, `runSample()`
- `build.zig`: tests 57/58 updated (use `parquet` as the truly unknown format now); 6 new XML integration tests (99–104)
- `docs/sql-pipe.1.scd` + `README.md`: updated format lists, new flag docs, XML usage example

Closes #99