### PR TITLE
fix: pass -Dbundle-sqlite=true to unit-test step in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
         run: zig build -Dbundle-sqlite=true -Doptimize=ReleaseSafe
 
       - name: Unit tests (csv.zig)
-        run: zig build unit-test
+        run: zig build unit-test -Dbundle-sqlite=true
 
       - name: Integration tests (build.zig)
         if: runner.os != 'Windows'


### PR DESCRIPTION
## Summary

- `zig build unit-test` failed on Windows because `xml.zig` tests link against sqlite3, which has no system library on Windows
- Adding `-Dbundle-sqlite=true` to the unit-test step makes it use the already-downloaded SQLite amalgamation, consistent with the build step
- One-line change, no code impact on Linux/macOS

Closes #136