### PR TITLE
refactor: eliminate code duplication and simplify core patterns

### DIFF
--- a/src/csv.zig
+++ b/src/csv.zig
@@ -331,14 +331,14 @@ test "simple unquoted fields, two records" {
 
     const r1 = (try csv.nextRecord()).?;
     defer csv.freeRecord(r1);
-    try std.testing.expectEqual(@as(usize, 3), r1.len);
+    try std.testing.expectEqual(3, r1.len);
     try std.testing.expectEqualStrings("a", r1[0]);
     try std.testing.expectEqualStrings("b", r1[1]);
     try std.testing.expectEqualStrings("c", r1[2]);
 
     const r2 = (try csv.nextRecord()).?;
     defer csv.freeRecord(r2);
-    try std.testing.expectEqual(@as(usize, 3), r2.len);
+    try std.testing.expectEqual(3, r2.len);
     try std.testing.expectEqualStrings("1", r2[0]);
     try std.testing.expectEqualStrings("2", r2[1]);
     try std.testing.expectEqualStrings("3", r2[2]);
@@ -353,7 +353,7 @@ test "quoted field with embedded comma" {
 
     const r = (try csv.nextRecord()).?;
     defer csv.freeRecord(r);
-    try std.testing.expectEqual(@as(usize, 2), r.len);
+    try std.testing.expectEqual(2, r.len);
     try std.testing.expectEqualStrings("hello, world", r[0]);
     try std.testing.expectEqualStrings("42", r[1]);
 }
@@ -365,7 +365,7 @@ test "escaped double-quote inside quoted field" {
 
     const r = (try csv.nextRecord()).?;
     defer csv.freeRecord(r);
-    try std.testing.expectEqual(@as(usize, 2), r.len);
+    try std.testing.expectEqual(2, r.len);
     try std.testing.expectEqualStrings("say \"hello\"", r[0]);
     try std.testing.expectEqualStrings("done", r[1]);
 }
@@ -382,7 +382,7 @@ test "quoted field with embedded newline (multi-line record)" {
 
     const r2 = (try csv.nextRecord()).?;
     defer csv.freeRecord(r2);
-    try std.testing.expectEqual(@as(usize, 2), r2.len);
+    try std.testing.expectEqual(2, r2.len);
     try std.testing.expectEqualStrings("1", r2[0]);
     try std.testing.expectEqualStrings("line one\nline two", r2[1]);
 
@@ -412,7 +412,7 @@ test "empty fields are preserved" {
 
     const r = (try csv.nextRecord()).?;
     defer csv.freeRecord(r);
-    try std.testing.expectEqual(@as(usize, 3), r.len);
+    try std.testing.expectEqual(3, r.len);
     try std.testing.expectEqualStrings("", r[0]);
     try std.testing.expectEqualStrings("middle", r[1]);
     try std.testing.expectEqualStrings("", r[2]);
@@ -425,7 +425,7 @@ test "no trailing newline at EOF" {
 
     const r = (try csv.nextRecord()).?;
     defer csv.freeRecord(r);
-    try std.testing.expectEqual(@as(usize, 2), r.len);
+    try std.testing.expectEqual(2, r.len);
     try std.testing.expectEqualStrings("x", r[0]);
     try std.testing.expectEqualStrings("y", r[1]);
 
@@ -439,7 +439,7 @@ test "quoted field ending at EOF without trailing newline" {
 
     const r = (try csv.nextRecord()).?;
     defer csv.freeRecord(r);
-    try std.testing.expectEqual(@as(usize, 1), r.len);
+    try std.testing.expectEqual(1, r.len);
     try std.testing.expectEqualStrings("value", r[0]);
 }
 
@@ -450,7 +450,7 @@ test "empty quoted field" {
 
     const r = (try csv.nextRecord()).?;
     defer csv.freeRecord(r);
-    try std.testing.expectEqual(@as(usize, 2), r.len);
+    try std.testing.expectEqual(2, r.len);
     try std.testing.expectEqualStrings("", r[0]);
     try std.testing.expectEqualStrings("b", r[1]);
 }
@@ -470,14 +470,14 @@ test "custom pipe delimiter" {
 
     const r1 = (try csv.nextRecord()).?;
     defer csv.freeRecord(r1);
-    try std.testing.expectEqual(@as(usize, 3), r1.len);
+    try std.testing.expectEqual(3, r1.len);
     try std.testing.expectEqualStrings("a", r1[0]);
     try std.testing.expectEqualStrings("b", r1[1]);
     try std.testing.expectEqualStrings("c", r1[2]);
 
     const r2 = (try csv.nextRecord()).?;
     defer csv.freeRecord(r2);
-    try std.testing.expectEqual(@as(usize, 3), r2.len);
+    try std.testing.expectEqual(3, r2.len);
     try std.testing.expectEqualStrings("1", r2[0]);
     try std.testing.expectEqualStrings("2", r2[1]);
     try std.testing.expectEqualStrings("3", r2[2]);
@@ -490,13 +490,13 @@ test "custom tab delimiter" {
 
     const r1 = (try csv.nextRecord()).?;
     defer csv.freeRecord(r1);
-    try std.testing.expectEqual(@as(usize, 2), r1.len);
+    try std.testing.expectEqual(2, r1.len);
     try std.testing.expectEqualStrings("name", r1[0]);
     try std.testing.expectEqualStrings("age", r1[1]);
 
     const r2 = (try csv.nextRecord()).?;
     defer csv.freeRecord(r2);
-    try std.testing.expectEqual(@as(usize, 2), r2.len);
+    try std.testing.expectEqual(2, r2.len);
     try std.testing.expectEqualStrings("Alice", r2[0]);
     try std.testing.expectEqualStrings("30", r2[1]);
 }
@@ -508,14 +508,14 @@ test "2-char delimiter (||) splits fields correctly" {
 
     const r1 = (try csv.nextRecord()).?;
     defer csv.freeRecord(r1);
-    try std.testing.expectEqual(@as(usize, 3), r1.len);
+    try std.testing.expectEqual(3, r1.len);
     try std.testing.expectEqualStrings("a", r1[0]);
     try std.testing.expectEqualStrings("b", r1[1]);
     try std.testing.expectEqualStrings("c", r1[2]);
 
     const r2 = (try csv.nextRecord()).?;
     defer csv.freeRecord(r2);
-    try std.testing.expectEqual(@as(usize, 3), r2.len);
+    try std.testing.expectEqual(3, r2.len);
     try std.testing.expectEqualStrings("1", r2[0]);
     try std.testing.expectEqualStrings("2", r2[1]);
     try std.testing.expectEqualStrings("3", r2[2]);
@@ -530,7 +530,7 @@ test "3-char delimiter (;;;) splits fields correctly" {
 
     const r = (try csv.nextRecord()).?;
     defer csv.freeRecord(r);
-    try std.testing.expectEqual(@as(usize, 3), r.len);
+    try std.testing.expectEqual(3, r.len);
     try std.testing.expectEqualStrings("foo", r[0]);
     try std.testing.expectEqualStrings("bar", r[1]);
     try std.testing.expectEqualStrings("baz", r[2]);
@@ -544,7 +544,7 @@ test "multi-char delimiter: partial match bytes emitted as field content" {
 
     const r = (try csv.nextRecord()).?;
     defer csv.freeRecord(r);
-    try std.testing.expectEqual(@as(usize, 2), r.len);
+    try std.testing.expectEqual(2, r.len);
     try std.testing.expectEqualStrings("a|b", r[0]);
     try std.testing.expectEqualStrings("c", r[1]);
 }
@@ -556,7 +556,7 @@ test "quoted field containing multi-char delimiter is preserved" {
 
     const r = (try csv.nextRecord()).?;
     defer csv.freeRecord(r);
-    try std.testing.expectEqual(@as(usize, 2), r.len);
+    try std.testing.expectEqual(2, r.len);
     try std.testing.expectEqualStrings("a||b", r[0]);
     try std.testing.expectEqualStrings("c", r[1]);
 }
@@ -568,7 +568,7 @@ test "multi-char delimiter: empty first field" {
 
     const r = (try csv.nextRecord()).?;
     defer csv.freeRecord(r);
-    try std.testing.expectEqual(@as(usize, 3), r.len);
+    try std.testing.expectEqual(3, r.len);
     try std.testing.expectEqualStrings("", r[0]);
     try std.testing.expectEqualStrings("b", r[1]);
     try std.testing.expectEqualStrings("c", r[2]);
@@ -581,7 +581,7 @@ test "multi-char delimiter: empty last field, no trailing newline" {
 
     const r = (try csv.nextRecord()).?;
     defer csv.freeRecord(r);
-    try std.testing.expectEqual(@as(usize, 3), r.len);
+    try std.testing.expectEqual(3, r.len);
     try std.testing.expectEqualStrings("a", r[0]);
     try std.testing.expectEqualStrings("b", r[1]);
     try std.testing.expectEqualStrings("", r[2]);
@@ -594,7 +594,7 @@ test "multi-char delimiter: only delimiter produces two empty fields" {
 
     const r = (try csv.nextRecord()).?;
     defer csv.freeRecord(r);
-    try std.testing.expectEqual(@as(usize, 2), r.len);
+    try std.testing.expectEqual(2, r.len);
     try std.testing.expectEqualStrings("", r[0]);
     try std.testing.expectEqualStrings("", r[1]);
 }
@@ -606,7 +606,7 @@ test "multi-char delimiter: EOF without trailing newline" {
 
     const r = (try csv.nextRecord()).?;
     defer csv.freeRecord(r);
-    try std.testing.expectEqual(@as(usize, 2), r.len);
+    try std.testing.expectEqual(2, r.len);
     try std.testing.expectEqualStrings("a", r[0]);
     try std.testing.expectEqualStrings("b", r[1]);
 
@@ -621,7 +621,7 @@ test "multi-char delimiter: partial delimiter at EOF treated as field content" {
 
     const r = (try csv.nextRecord()).?;
     defer csv.freeRecord(r);
-    try std.testing.expectEqual(@as(usize, 1), r.len);
+    try std.testing.expectEqual(1, r.len);
     try std.testing.expectEqualStrings("a|", r[0]);
 }
 
@@ -634,7 +634,7 @@ test "multi-char delimiter: greedy left-to-right matching" {
 
     const r = (try csv.nextRecord()).?;
     defer csv.freeRecord(r);
-    try std.testing.expectEqual(@as(usize, 2), r.len);
+    try std.testing.expectEqual(2, r.len);
     try std.testing.expectEqualStrings("a", r[0]);
     try std.testing.expectEqualStrings("|b", r[1]);
 }

--- a/src/format.zig
+++ b/src/format.zig
@@ -26,12 +26,7 @@ pub const InputFormat = enum {
     /// Parse a format name string.
     /// Returns error.InvalidInputFormat when the value is unrecognised.
     pub fn parse(s: []const u8) error{InvalidInputFormat}!InputFormat {
-        if (std.mem.eql(u8, s, "csv")) return .csv;
-        if (std.mem.eql(u8, s, "tsv")) return .tsv;
-        if (std.mem.eql(u8, s, "json")) return .json;
-        if (std.mem.eql(u8, s, "ndjson")) return .ndjson;
-        if (std.mem.eql(u8, s, "xml")) return .xml;
-        return error.InvalidInputFormat;
+        return std.meta.stringToEnum(InputFormat, s) orelse error.InvalidInputFormat;
     }
 };
 
@@ -48,12 +43,7 @@ pub const OutputFormat = enum {
     /// Parse a format name string.
     /// Returns error.InvalidOutputFormat when the value is unrecognised.
     pub fn parse(s: []const u8) error{InvalidOutputFormat}!OutputFormat {
-        if (std.mem.eql(u8, s, "csv")) return .csv;
-        if (std.mem.eql(u8, s, "tsv")) return .tsv;
-        if (std.mem.eql(u8, s, "json")) return .json;
-        if (std.mem.eql(u8, s, "ndjson")) return .ndjson;
-        if (std.mem.eql(u8, s, "xml")) return .xml;
-        return error.InvalidOutputFormat;
+        return std.meta.stringToEnum(OutputFormat, s) orelse error.InvalidOutputFormat;
     }
 };
 

--- a/src/loader.zig
+++ b/src/loader.zig
@@ -371,13 +371,7 @@ pub fn loadCsvInput(
 
     sqlite_mod.createTable(allocator, db, cols, types, stderr_writer);
 
-    {
-        var errmsg: [*c]u8 = null;
-        if (c.sqlite3_exec(db, "BEGIN TRANSACTION", null, null, &errmsg) != c.SQLITE_OK) {
-            const msg = if (errmsg != null) std.mem.span(errmsg) else std.mem.span(c.sqlite3_errmsg(db));
-            fatalSqlWithContext(allocator, db, msg, stderr_writer);
-        }
-    }
+    sqlite_mod.beginTransaction(db, stderr_writer);
 
     const stmt = sqlite_mod.prepareInsertStmt(allocator, db, num_cols, stderr_writer);
     defer _ = c.sqlite3_finalize(stmt);
@@ -430,15 +424,7 @@ pub fn loadCsvInput(
             printProgress(stderr_writer, rows_inserted, parsed.max_rows);
     }
 
-    {
-        var errmsg: [*c]u8 = null;
-        const rc = c.sqlite3_exec(db, "COMMIT", null, null, &errmsg);
-        if (rc != c.SQLITE_OK) {
-            const msg = if (errmsg != null) std.mem.span(errmsg) else std.mem.span(c.sqlite3_errmsg(db));
-            fatalSqlWithContext(allocator, db, msg, stderr_writer);
-        }
-        if (errmsg != null) c.sqlite3_free(errmsg);
-    }
+    sqlite_mod.commitTransaction(db, stderr_writer);
 
     return rows_inserted;
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -23,6 +23,7 @@ const printUsage = args_mod.printUsage;
 const loadCsvInput = loader.loadCsvInput;
 const fmtThousands = loader.fmtThousands;
 const progress_interval = loader.progress_interval;
+const fatal = sqlite_mod.fatal;
 
 /// Supported input formats (canonical definition lives in format.zig).
 const InputFormat = format.InputFormat;
@@ -72,17 +73,6 @@ fn execQuery(
         try out_writer.writeRow(stmt.?, writer);
     }
     try out_writer.end(writer);
-}
-
-/// fatal(writer, code, comptime fmt, args) → noreturn
-/// Pre:  writer is stderr, code is non-zero ExitCode
-/// Post: "error: <message>\n" written to stderr, process exits with code
-fn fatal(comptime fmt: []const u8, writer: *std.Io.Writer, code: ExitCode, args: anytype) noreturn {
-    writer.print("error: " ++ fmt ++ "\n", args) catch |err| {
-        std.log.err("failed to write error message: {}", .{err});
-    };
-    writer.flush() catch |err| std.log.err("failed to flush: {}", .{err});
-    std.process.exit(@intFromEnum(code));
 }
 
 /// run(allocator, io, parsed, stderr_writer, stdout_writer) → void
@@ -178,144 +168,28 @@ pub fn main(init: std.process.Init.Minimal) void {
 
     const args_result = parseArgs(args) catch |err| {
         switch (err) {
-            error.IncompatibleFlags => {
-                stderr_writer.writeAll(
-                    "error: --header cannot be combined with non-CSV/TSV output format\n",
-                ) catch |werr| std.log.err("failed to write error message: {}", .{werr});
-                stderr_writer.flush() catch |ferr| std.log.err("failed to flush: {}", .{ferr});
-                std.process.exit(@intFromEnum(ExitCode.usage));
-            },
-            error.SilentVerboseConflict => {
-                stderr_writer.writeAll(
-                    "error: --silent cannot be combined with --verbose\n",
-                ) catch |werr| std.log.err("failed to write error message: {}", .{werr});
-                stderr_writer.flush() catch |ferr| std.log.err("failed to flush: {}", .{ferr});
-                std.process.exit(@intFromEnum(ExitCode.usage));
-            },
-            error.InvalidMaxRows => {
-                stderr_writer.writeAll("error: --max-rows must be a positive integer\n") catch |werr| {
-                    std.log.err("failed to write error message: {}", .{werr});
-                };
-                stderr_writer.flush() catch |ferr| std.log.err("failed to flush: {}", .{ferr});
-                std.process.exit(@intFromEnum(ExitCode.usage));
-            },
-            error.InvalidInputFormat => {
-                stderr_writer.writeAll(
-                    "error: unknown input format; supported: csv, tsv, json, ndjson, xml\n",
-                ) catch |werr| std.log.err("failed to write error message: {}", .{werr});
-                stderr_writer.flush() catch |ferr| std.log.err("failed to flush: {}", .{ferr});
-                std.process.exit(@intFromEnum(ExitCode.usage));
-            },
-            error.InvalidOutputFormat => {
-                stderr_writer.writeAll(
-                    "error: unknown output format; supported: csv, tsv, json, ndjson, xml\n",
-                ) catch |werr| std.log.err("failed to write error message: {}", .{werr});
-                stderr_writer.flush() catch |ferr| std.log.err("failed to flush: {}", .{ferr});
-                std.process.exit(@intFromEnum(ExitCode.usage));
-            },
-            error.ColumnsWithQuery => {
-                stderr_writer.writeAll("error: --columns cannot be combined with a query argument\n") catch |werr| {
-                    std.log.err("failed to write error message: {}", .{werr});
-                };
-                stderr_writer.flush() catch |ferr| std.log.err("failed to flush: {}", .{ferr});
-                std.process.exit(@intFromEnum(ExitCode.usage));
-            },
-            error.ValidateWithQuery => {
-                stderr_writer.writeAll("error: --validate cannot be combined with a query argument\n") catch |werr| {
-                    std.log.err("failed to write error message: {}", .{werr});
-                };
-                stderr_writer.flush() catch |ferr| std.log.err("failed to flush: {}", .{ferr});
-                std.process.exit(@intFromEnum(ExitCode.usage));
-            },
-            error.InvalidOutputPath => {
-                stderr_writer.writeAll("error: --output requires a non-empty file path\n") catch |werr| {
-                    std.log.err("failed to write error message: {}", .{werr});
-                };
-                stderr_writer.flush() catch |ferr| std.log.err("failed to flush: {}", .{ferr});
-                std.process.exit(@intFromEnum(ExitCode.usage));
-            },
-            error.OutputWithColumns => {
-                stderr_writer.writeAll("error: --output cannot be combined with --columns\n") catch |werr| {
-                    std.log.err("failed to write error message: {}", .{werr});
-                };
-                stderr_writer.flush() catch |ferr| std.log.err("failed to flush: {}", .{ferr});
-                std.process.exit(@intFromEnum(ExitCode.usage));
-            },
-            error.OutputWithValidate => {
-                stderr_writer.writeAll("error: --output cannot be combined with --validate\n") catch |werr| {
-                    std.log.err("failed to write error message: {}", .{werr});
-                };
-                stderr_writer.flush() catch |ferr| std.log.err("failed to flush: {}", .{ferr});
-                std.process.exit(@intFromEnum(ExitCode.usage));
-            },
-            error.ValidateWithColumns => {
-                stderr_writer.writeAll("error: --validate cannot be combined with --columns\n") catch |werr| {
-                    std.log.err("failed to write error message: {}", .{werr});
-                };
-                stderr_writer.flush() catch |ferr| std.log.err("failed to flush: {}", .{ferr});
-                std.process.exit(@intFromEnum(ExitCode.usage));
-            },
-            error.SampleWithQuery => {
-                stderr_writer.writeAll("error: --sample cannot be combined with a query argument\n") catch |werr| {
-                    std.log.err("failed to write error message: {}", .{werr});
-                };
-                stderr_writer.flush() catch |ferr| std.log.err("failed to flush: {}", .{ferr});
-                std.process.exit(@intFromEnum(ExitCode.usage));
-            },
-            error.SampleWithJson => {
-                stderr_writer.writeAll("error: --sample cannot be combined with --json or a JSON output format\n") catch |werr| {
-                    std.log.err("failed to write error message: {}", .{werr});
-                };
-                stderr_writer.flush() catch |ferr| std.log.err("failed to flush: {}", .{ferr});
-                std.process.exit(@intFromEnum(ExitCode.usage));
-            },
-            error.SampleWithColumns => {
-                stderr_writer.writeAll("error: --sample cannot be combined with --columns\n") catch |werr| {
-                    std.log.err("failed to write error message: {}", .{werr});
-                };
-                stderr_writer.flush() catch |ferr| std.log.err("failed to flush: {}", .{ferr});
-                std.process.exit(@intFromEnum(ExitCode.usage));
-            },
-            error.SampleWithValidate => {
-                stderr_writer.writeAll("error: --sample cannot be combined with --validate\n") catch |werr| {
-                    std.log.err("failed to write error message: {}", .{werr});
-                };
-                stderr_writer.flush() catch |ferr| std.log.err("failed to flush: {}", .{ferr});
-                std.process.exit(@intFromEnum(ExitCode.usage));
-            },
-            error.SampleWithOutput => {
-                stderr_writer.writeAll("error: --sample cannot be combined with --output\n") catch |werr| {
-                    std.log.err("failed to write error message: {}", .{werr});
-                };
-                stderr_writer.flush() catch |ferr| std.log.err("failed to flush: {}", .{ferr});
-                std.process.exit(@intFromEnum(ExitCode.usage));
-            },
-            error.InvalidSampleCount => {
-                stderr_writer.writeAll("error: --sample requires a positive integer value\n") catch |werr| {
-                    std.log.err("failed to write error message: {}", .{werr});
-                };
-                stderr_writer.flush() catch |ferr| std.log.err("failed to flush: {}", .{ferr});
-                std.process.exit(@intFromEnum(ExitCode.usage));
-            },
-            error.MissingXmlFlagValue => {
-                stderr_writer.writeAll(
-                    "error: --xml-root and --xml-row require a value\n",
-                ) catch |werr| std.log.err("failed to write error message: {}", .{werr});
-                stderr_writer.flush() catch |ferr| std.log.err("failed to flush: {}", .{ferr});
-                std.process.exit(@intFromEnum(ExitCode.usage));
-            },
-            error.InvalidXmlName => {
-                stderr_writer.writeAll(
-                    "error: --xml-root and --xml-row must be valid XML element names (letter/underscore first, then letters/digits/-/._/:)\n",
-                ) catch |werr| std.log.err("failed to write error message: {}", .{werr});
-                stderr_writer.flush() catch |ferr| std.log.err("failed to flush: {}", .{ferr});
-                std.process.exit(@intFromEnum(ExitCode.usage));
-            },
+            error.IncompatibleFlags => fatal("--header cannot be combined with non-CSV/TSV output format", stderr_writer, .usage, .{}),
+            error.SilentVerboseConflict => fatal("--silent cannot be combined with --verbose", stderr_writer, .usage, .{}),
+            error.InvalidMaxRows => fatal("--max-rows must be a positive integer", stderr_writer, .usage, .{}),
+            error.InvalidInputFormat => fatal("unknown input format; supported: csv, tsv, json, ndjson, xml", stderr_writer, .usage, .{}),
+            error.InvalidOutputFormat => fatal("unknown output format; supported: csv, tsv, json, ndjson, xml", stderr_writer, .usage, .{}),
+            error.ColumnsWithQuery => fatal("--columns cannot be combined with a query argument", stderr_writer, .usage, .{}),
+            error.ValidateWithQuery => fatal("--validate cannot be combined with a query argument", stderr_writer, .usage, .{}),
+            error.InvalidOutputPath => fatal("--output requires a non-empty file path", stderr_writer, .usage, .{}),
+            error.OutputWithColumns => fatal("--output cannot be combined with --columns", stderr_writer, .usage, .{}),
+            error.OutputWithValidate => fatal("--output cannot be combined with --validate", stderr_writer, .usage, .{}),
+            error.ValidateWithColumns => fatal("--validate cannot be combined with --columns", stderr_writer, .usage, .{}),
+            error.SampleWithQuery => fatal("--sample cannot be combined with a query argument", stderr_writer, .usage, .{}),
+            error.SampleWithJson => fatal("--sample cannot be combined with --json or a JSON output format", stderr_writer, .usage, .{}),
+            error.SampleWithColumns => fatal("--sample cannot be combined with --columns", stderr_writer, .usage, .{}),
+            error.SampleWithValidate => fatal("--sample cannot be combined with --validate", stderr_writer, .usage, .{}),
+            error.SampleWithOutput => fatal("--sample cannot be combined with --output", stderr_writer, .usage, .{}),
+            error.InvalidSampleCount => fatal("--sample requires a positive integer value", stderr_writer, .usage, .{}),
+            error.MissingXmlFlagValue => fatal("--xml-root and --xml-row require a value", stderr_writer, .usage, .{}),
+            error.InvalidXmlName => fatal("--xml-root and --xml-row must be valid XML element names (letter/underscore first, then letters/digits/-/._/:)", stderr_writer, .usage, .{}),
             else => {},
         }
-        printUsage(stderr_writer) catch |werr| {
-            std.log.err("failed to write usage: {}", .{werr});
-        };
+        printUsage(stderr_writer) catch |werr| std.log.err("failed to write usage: {}", .{werr});
         stderr_writer.flush() catch |ferr| std.log.err("failed to flush: {}", .{ferr});
         std.process.exit(@intFromEnum(ExitCode.usage));
     };

--- a/src/modes/columns.zig
+++ b/src/modes/columns.zig
@@ -10,14 +10,7 @@ const parseHeader = loader.parseHeader;
 const inference_buffer_size = loader.inference_buffer_size;
 
 const ExitCode = args_mod.ExitCode;
-
-fn fatal(comptime fmt: []const u8, writer: *std.Io.Writer, code: ExitCode, f_args: anytype) noreturn {
-    writer.print("error: " ++ fmt ++ "\n", f_args) catch |err| {
-        std.log.err("failed to write error message: {}", .{err});
-    };
-    writer.flush() catch |err| std.log.err("failed to flush: {}", .{err});
-    std.process.exit(@intFromEnum(code));
-}
+const fatal = @import("../sqlite.zig").fatal;
 
 pub fn runColumns(
     allocator: std.mem.Allocator,
@@ -94,18 +87,14 @@ pub fn runColumns(
             var stdin_buf: [4096]u8 = undefined;
             var stdin_file_reader = std.Io.File.reader(std.Io.File.stdin(), io, &stdin_buf);
 
-            var buf: std.ArrayList(u8) = .empty;
-            defer buf.deinit(allocator);
-            while (true) {
-                const byte = stdin_file_reader.interface.takeByte() catch |err| switch (err) {
-                    error.EndOfStream => break,
-                    error.ReadFailed => fatal("failed to read JSON input", stderr_writer, .csv_error, .{}),
-                };
-                buf.append(allocator, byte) catch fatal("out of memory reading JSON", stderr_writer, .csv_error, .{});
-            }
-            if (buf.items.len == 0) fatal("empty input", stderr_writer, .csv_error, .{});
+            const input = stdin_file_reader.interface.allocRemaining(allocator, .unlimited) catch |err| switch (err) {
+                error.OutOfMemory => fatal("out of memory reading JSON input", stderr_writer, .csv_error, .{}),
+                error.ReadFailed, error.StreamTooLong => fatal("failed to read JSON input", stderr_writer, .csv_error, .{}),
+            };
+            defer allocator.free(input);
+            if (input.len == 0) fatal("empty input", stderr_writer, .csv_error, .{});
 
-            var parsed = std.json.parseFromSlice(std.json.Value, allocator, buf.items, .{}) catch
+            var parsed = std.json.parseFromSlice(std.json.Value, allocator, input, .{}) catch
                 fatal("failed to parse JSON input", stderr_writer, .csv_error, .{});
             defer parsed.deinit();
 

--- a/src/modes/sample.zig
+++ b/src/modes/sample.zig
@@ -11,14 +11,7 @@ const parseHeader = loader.parseHeader;
 const inference_buffer_size = loader.inference_buffer_size;
 
 const ExitCode = args_mod.ExitCode;
-
-fn fatal(comptime fmt: []const u8, writer: *std.Io.Writer, code: ExitCode, f_args: anytype) noreturn {
-    writer.print("error: " ++ fmt ++ "\n", f_args) catch |err| {
-        std.log.err("failed to write error message: {}", .{err});
-    };
-    writer.flush() catch |err| std.log.err("failed to flush: {}", .{err});
-    std.process.exit(@intFromEnum(code));
-}
+const fatal = @import("../sqlite.zig").fatal;
 
 pub fn runSample(
     allocator: std.mem.Allocator,

--- a/src/modes/validate.zig
+++ b/src/modes/validate.zig
@@ -13,14 +13,7 @@ const fmtThousands = loader.fmtThousands;
 const inference_buffer_size = loader.inference_buffer_size;
 
 const ExitCode = args_mod.ExitCode;
-
-fn fatal(comptime fmt: []const u8, writer: *std.Io.Writer, code: ExitCode, f_args: anytype) noreturn {
-    writer.print("error: " ++ fmt ++ "\n", f_args) catch |err| {
-        std.log.err("failed to write error message: {}", .{err});
-    };
-    writer.flush() catch |err| std.log.err("failed to flush: {}", .{err});
-    std.process.exit(@intFromEnum(code));
-}
+const fatal = @import("../sqlite.zig").fatal;
 
 pub fn runValidate(
     allocator: std.mem.Allocator,
@@ -150,18 +143,14 @@ pub fn runValidate(
             var stdin_buf: [4096]u8 = undefined;
             var stdin_file_reader = std.Io.File.reader(std.Io.File.stdin(), io, &stdin_buf);
 
-            var buf: std.ArrayList(u8) = .empty;
-            defer buf.deinit(allocator);
-            while (true) {
-                const byte = stdin_file_reader.interface.takeByte() catch |err| switch (err) {
-                    error.EndOfStream => break,
-                    error.ReadFailed => fatal("failed to read JSON input", stderr_writer, .csv_error, .{}),
-                };
-                buf.append(allocator, byte) catch fatal("out of memory reading JSON", stderr_writer, .csv_error, .{});
-            }
-            if (buf.items.len == 0) fatal("empty input", stderr_writer, .csv_error, .{});
+            const input = stdin_file_reader.interface.allocRemaining(allocator, .unlimited) catch |err| switch (err) {
+                error.OutOfMemory => fatal("out of memory reading JSON input", stderr_writer, .csv_error, .{}),
+                error.ReadFailed, error.StreamTooLong => fatal("failed to read JSON input", stderr_writer, .csv_error, .{}),
+            };
+            defer allocator.free(input);
+            if (input.len == 0) fatal("empty input", stderr_writer, .csv_error, .{});
 
-            var parsed = std.json.parseFromSlice(std.json.Value, allocator, buf.items, .{}) catch
+            var parsed = std.json.parseFromSlice(std.json.Value, allocator, input, .{}) catch
                 fatal("failed to parse JSON input", stderr_writer, .csv_error, .{});
             defer parsed.deinit();
 


### PR DESCRIPTION
## Summary

- **`fatal()` deduplicated**: the 4 identical copies in `main.zig`, `modes/columns.zig`, `modes/validate.zig`, and `modes/sample.zig` removed — all now import the `pub fn` from `sqlite.zig`.
- **Error switch in `main()` collapsed**: from ~100 lines with 19 `writeAll → flush → exit` blocks down to 22 lines using `fatal()` directly (it is `noreturn`).
- **`parse()` simplified in `format.zig`**: chains of `if (mem.eql(...))` replaced by `std.meta.stringToEnum` — automatically stays in sync with the enum.
- **Transactions in `loader.zig`**: inline `sqlite3_exec("BEGIN"/"COMMIT")` replaced by the `beginTransaction`/`commitTransaction` helpers from `sqlite.zig`.
- **JSON reading fixed**: `while (takeByte())` loop in `columns.zig` and `validate.zig` replaced by `allocRemaining(.unlimited)`.
- **Tests cleaned up**: 24 unnecessary `@as(usize, N)` casts removed in `csv.zig`.

## Impact

No behaviour change. Pure refactoring.

```
7 files changed, 66 insertions(+), 245 deletions(-)
```

## Checklist

- [x] `zig build test` — all tests pass
- [x] `ziglint src build.zig` — clean