### PR TITLE
feat: disk-backed large dataset support (--disk flag)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1282,6 +1282,8 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&test_disk_tsv.step);
 
     // Integration test 125: --disk with NDJSON input
+    // age column is TEXT (NDJSON uses createAllTextTable); comparison works via
+    // SQLite implicit TEXT→NUMERIC conversion when compared against a numeric literal.
     const test_disk_ndjson = b.addSystemCommand(&.{
         "bash", "-c",
         \\result=$(printf '{"name":"Alice","age":30}\n{"name":"Bob","age":25}\n' \
@@ -1292,6 +1294,8 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&test_disk_ndjson.step);
 
     // Integration test 126: --disk with JSON input
+    // age column is TEXT (JSON uses createAllTextTable); comparison works via
+    // SQLite implicit TEXT→NUMERIC conversion when compared against a numeric literal.
     const test_disk_json = b.addSystemCommand(&.{
         "bash", "-c",
         \\result=$(printf '[{"name":"Alice","age":30},{"name":"Bob","age":25}]' \
@@ -1302,6 +1306,8 @@ pub fn build(b: *std.Build) void {
     test_step.dependOn(&test_disk_json.step);
 
     // Integration test 127: --disk with XML input
+    // age column is TEXT (XML uses createAllTextTable); comparison works via
+    // SQLite implicit TEXT→NUMERIC conversion when compared against a numeric literal.
     const test_disk_xml = b.addSystemCommand(&.{
         "bash", "-c",
         \\result=$(printf '<data><row><name>Alice</name><age>30</age></row><row><name>Bob</name><age>25</age></row></data>' \
@@ -1320,6 +1326,41 @@ pub fn build(b: *std.Build) void {
     });
     test_disk_group_by.step.dependOn(b.getInstallStep());
     test_step.dependOn(&test_disk_group_by.step);
+
+    // Integration test 129: --disk with --no-type-inference (all TEXT columns)
+    // Uses SQLite implicit TEXT→NUMERIC conversion for the numeric comparison.
+    const test_disk_no_type_inference = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\result=$(printf 'name,age\nAlice,30\nBob,25\nCarol,35' \
+        \\    | ./zig-out/bin/sql-pipe --disk --no-type-inference \
+        \\    'SELECT name FROM t WHERE age > 27 ORDER BY name')
+        \\[ "$result" = "$(printf 'Alice\nCarol')" ]
+    });
+    test_disk_no_type_inference.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_disk_no_type_inference.step);
+
+    // Integration test 130: --disk with --header outputs column names in first row
+    const test_disk_header = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\result=$(printf 'name,age\nAlice,30\nBob,25\n' \
+        \\    | ./zig-out/bin/sql-pipe --disk --header 'SELECT name, age FROM t ORDER BY age')
+        \\[ "$result" = "$(printf 'name,age\nBob,25\nAlice,30')" ]
+    });
+    test_disk_header.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_disk_header.step);
+
+    // Integration test 131: --disk with --output writes results to file
+    const test_disk_output = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\tmp=$(mktemp)
+        \\printf 'name,val\nA,10\nB,20\n' \
+        \\    | ./zig-out/bin/sql-pipe --disk --output "$tmp" 'SELECT name FROM t WHERE val > 15'
+        \\result=$(cat "$tmp")
+        \\rm -f "$tmp"
+        \\[ "$result" = "B" ]
+    });
+    test_disk_output.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_disk_output.step);
 
     // Unit tests for the RFC 4180 CSV parser (src/csv.zig)
     const unit_tests = b.addTest(.{

--- a/build.zig
+++ b/build.zig
@@ -1241,6 +1241,86 @@ pub fn build(b: *std.Build) void {
     test_xml_root_fast_path.step.dependOn(b.getInstallStep());
     test_step.dependOn(&test_xml_root_fast_path.step);
 
+    // Integration test 121: --disk produces correct output for CSV input
+    const test_disk_csv = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\result=$(printf 'name,age\nAlice,30\nBob,25\nCarol,35' \
+        \\    | ./zig-out/bin/sql-pipe --disk 'SELECT name FROM t WHERE age > 27 ORDER BY name')
+        \\[ "$result" = "$(printf 'Alice\nCarol')" ]
+    });
+    test_disk_csv.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_disk_csv.step);
+
+    // Integration test 122: --disk produces same results as in-memory for aggregates
+    const test_disk_aggregate = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\result=$(printf 'item,price\nA,9.99\nB,3.00\nC,12.50\n' \
+        \\    | ./zig-out/bin/sql-pipe --disk 'SELECT max(price), min(price) FROM t')
+        \\[ "$result" = "12.5,3.0" ]
+    });
+    test_disk_aggregate.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_disk_aggregate.step);
+
+    // Integration test 123: --disk with ORDER BY (exercises PRAGMA temp_store = FILE)
+    const test_disk_order_by = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\result=$(printf 'name,score\nZara,90\nAna,85\nMike,92\n' \
+        \\    | ./zig-out/bin/sql-pipe --disk 'SELECT name FROM t ORDER BY score DESC')
+        \\[ "$result" = "$(printf 'Mike\nZara\nAna')" ]
+    });
+    test_disk_order_by.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_disk_order_by.step);
+
+    // Integration test 124: --disk with TSV input
+    const test_disk_tsv = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\result=$(printf 'name\tval\nFoo\t10\nBar\t20\n' \
+        \\    | ./zig-out/bin/sql-pipe --disk --tsv 'SELECT name FROM t WHERE val > 15')
+        \\[ "$result" = "Bar" ]
+    });
+    test_disk_tsv.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_disk_tsv.step);
+
+    // Integration test 125: --disk with NDJSON input
+    const test_disk_ndjson = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\result=$(printf '{"name":"Alice","age":30}\n{"name":"Bob","age":25}\n' \
+        \\    | ./zig-out/bin/sql-pipe --disk -I ndjson 'SELECT name FROM t WHERE age > 27')
+        \\[ "$result" = "Alice" ]
+    });
+    test_disk_ndjson.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_disk_ndjson.step);
+
+    // Integration test 126: --disk with JSON input
+    const test_disk_json = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\result=$(printf '[{"name":"Alice","age":30},{"name":"Bob","age":25}]' \
+        \\    | ./zig-out/bin/sql-pipe --disk -I json 'SELECT name FROM t WHERE age > 27')
+        \\[ "$result" = "Alice" ]
+    });
+    test_disk_json.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_disk_json.step);
+
+    // Integration test 127: --disk with XML input
+    const test_disk_xml = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\result=$(printf '<data><row><name>Alice</name><age>30</age></row><row><name>Bob</name><age>25</age></row></data>' \
+        \\    | ./zig-out/bin/sql-pipe --disk -I xml 'SELECT name FROM t WHERE age > 27')
+        \\[ "$result" = "Alice" ]
+    });
+    test_disk_xml.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_disk_xml.step);
+
+    // Integration test 128: --disk with GROUP BY
+    const test_disk_group_by = b.addSystemCommand(&.{
+        "bash", "-c",
+        \\result=$(printf 'region,revenue\nEast,100\nWest,200\nEast,150\nWest,50\n' \
+        \\    | ./zig-out/bin/sql-pipe --disk 'SELECT region, SUM(revenue) FROM t GROUP BY region ORDER BY region')
+        \\[ "$result" = "$(printf 'East,250\nWest,250')" ]
+    });
+    test_disk_group_by.step.dependOn(b.getInstallStep());
+    test_step.dependOn(&test_disk_group_by.step);
+
     // Unit tests for the RFC 4180 CSV parser (src/csv.zig)
     const unit_tests = b.addTest(.{
         .root_module = b.createModule(.{

--- a/src/args.zig
+++ b/src/args.zig
@@ -249,7 +249,8 @@ pub fn parseArgs(args: []const [:0]const u8) SqlPipeError!ArgsResult {
     //   header reflects the presence of --header/-H;
     //   output_format reflects the last --output-format/--json flag seen;
     //   input_format reflects the last --input-format flag seen;
-    //   max_rows reflects the presence of --max-rows
+    //   max_rows reflects the presence of --max-rows;
+    //   disk reflects the presence of --disk
     // Bounding function: args.len - i
     var i: usize = 1;
     while (i < args.len) : (i += 1) {

--- a/src/args.zig
+++ b/src/args.zig
@@ -82,6 +82,9 @@ pub const ParsedArgs = struct {
     xml_root_input: ?[]const u8,
     /// Row tag filter for XML input; null = accept any direct child element as a row.
     xml_row_input: ?[]const u8,
+    /// Use a file-backed temporary SQLite database instead of :memory: when true.
+    /// Enables processing datasets larger than available RAM; also sets PRAGMA temp_store = FILE.
+    disk: bool,
 };
 
 pub const ColumnsArgs = struct {
@@ -170,6 +173,9 @@ pub fn printUsage(writer: *std.Io.Writer) !void {
         \\  --output <file>              Write results to file instead of stdout
         \\  --xml-root <name>            Root element name for XML I/O (default: results)
         \\  --xml-row <name>             Row element name for XML I/O (default: row)
+        \\  --disk                       Use a file-backed temp database instead of :memory:
+        \\                               Enables processing datasets larger than available RAM
+        \\                               Also sets PRAGMA temp_store = FILE for transient structures
         \\  -h, --help                   Show this help message and exit
         \\  -V, --version                Show version and exit
         \\
@@ -234,6 +240,7 @@ pub fn parseArgs(args: []const [:0]const u8) SqlPipeError!ArgsResult {
     var xml_row_input: ?[]const u8 = null;
     var sample_mode = false;
     var sample_n: usize = 10;
+    var disk = false;
 
     // Loop invariant I: all args[1..i] have been processed;
     //   query holds the first non-flag argument seen, or null;
@@ -346,6 +353,8 @@ pub fn parseArgs(args: []const [:0]const u8) SqlPipeError!ArgsResult {
         } else if (std.mem.startsWith(u8, arg, "--xml-row=")) {
             xml_row = arg["--xml-row=".len..];
             xml_row_input = arg["--xml-row=".len..];
+        } else if (std.mem.eql(u8, arg, "--disk")) {
+            disk = true;
         } else {
             if (query == null) query = arg;
         }
@@ -449,5 +458,6 @@ pub fn parseArgs(args: []const [:0]const u8) SqlPipeError!ArgsResult {
         .xml_row = xml_row,
         .xml_root_input = xml_root_input,
         .xml_row_input = xml_row_input,
+        .disk = disk,
     } };
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -90,7 +90,7 @@ fn run(
 ) void {
     const query = parsed.query;
 
-    const db = sqlite_mod.openDb(stderr_writer);
+    const db = sqlite_mod.openDb(parsed.disk, stderr_writer);
     defer _ = c.sqlite3_close(db);
 
     const start_ts = std.Io.Timestamp.now(io, .awake);

--- a/src/sqlite.zig
+++ b/src/sqlite.zig
@@ -95,13 +95,37 @@ pub fn commitTransaction(db: *c.sqlite3, writer: *std.Io.Writer) void {
     }
 }
 
-/// openDb(writer) → *sqlite3
+/// openDb(disk, writer) → *sqlite3
 /// Pre:  —
-/// Post: result is an open, empty in-memory SQLite database handle
-pub fn openDb(writer: *std.Io.Writer) *c.sqlite3 {
+/// Post: result is an open, empty SQLite database handle.
+///       When disk=false: in-memory database (`:memory:`).
+///       When disk=true:  file-backed private temp database (`""`); SQLite
+///         creates a temp file and deletes it automatically on close.
+///         PRAGMA temp_store = FILE is set so ORDER BY / GROUP BY transient
+///         structures also spill to disk rather than RAM.
+///         Exits with sql_error if the temp directory is not writable.
+pub fn openDb(disk: bool, writer: *std.Io.Writer) *c.sqlite3 {
     var db: ?*c.sqlite3 = null;
-    if (c.sqlite3_open(":memory:", &db) != c.SQLITE_OK)
-        fatal("failed to open in-memory database", writer, .sql_error, .{});
+    if (!disk) {
+        if (c.sqlite3_open(":memory:", &db) != c.SQLITE_OK)
+            fatal("failed to open in-memory database", writer, .sql_error, .{});
+        return db.?;
+    }
+
+    // Empty string → SQLite private temp file, deleted on close.
+    if (c.sqlite3_open("", &db) != c.SQLITE_OK) {
+        const msg = std.mem.span(c.sqlite3_errmsg(db));
+        fatal("failed to open temporary database (is the temp directory writable?): {s}", writer, .sql_error, .{msg});
+    }
+
+    // Ensure transient structures (ORDER BY sorts, GROUP BY indices) also spill to disk.
+    var errmsg: [*c]u8 = null;
+    if (c.sqlite3_exec(db.?, "PRAGMA temp_store = FILE", null, null, &errmsg) != c.SQLITE_OK) {
+        const msg = if (errmsg != null) std.mem.span(errmsg) else std.mem.span(c.sqlite3_errmsg(db));
+        if (errmsg != null) c.sqlite3_free(errmsg);
+        fatal("failed to set PRAGMA temp_store = FILE: {s}", writer, .sql_error, .{msg});
+    }
+
     return db.?;
 }
 


### PR DESCRIPTION
## Summary

- Adds `--disk` flag to switch from `:memory:` to a file-backed SQLite private temp database (SQLite deletes it automatically on close)
- Sets `PRAGMA temp_store = FILE` when `--disk` is active, so transient structures (ORDER BY sorts, GROUP BY indices) also spill to disk
- Works across all input formats: CSV, TSV, JSON, NDJSON, XML
- Error message emitted if the temp directory is not writable (surfaced from SQLite)
- Default behavior unchanged (`:memory:` when `--disk` is not set)

## Changes

- `src/args.zig`: add `disk: bool` field to `ParsedArgs`, parse `--disk` flag, document in `--help`
- `src/sqlite.zig`: extend `openDb(disk, writer)` — open `""` temp file + set `PRAGMA temp_store = FILE` when `disk=true`
- `src/main.zig`: pass `parsed.disk` to `openDb`
- `build.zig`: 8 new integration tests (121–128) covering CSV, TSV, JSON, NDJSON, XML, ORDER BY, GROUP BY, aggregates

Closes #91