### PR TITLE
perf: replace byte-by-byte takeByte() with block reads in xml.zig and json.zig

### DIFF
--- a/src/json.zig
+++ b/src/json.zig
@@ -179,22 +179,17 @@ pub fn loadJsonArray(
     max_rows: ?usize,
     stderr_writer: *std.Io.Writer,
 ) usize {
-    // Read all input into a buffer
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(allocator);
-    // Loop invariant I: buf contains all bytes read from reader so far
-    // Bounding function: bytes remaining in reader (finite input)
-    while (true) {
-        const byte = reader.takeByte() catch |err| switch (err) {
-            error.EndOfStream => break,
-            error.ReadFailed => fatal("failed to read JSON input", stderr_writer, .csv_error, .{}),
-        };
-        buf.append(allocator, byte) catch fatal("out of memory reading JSON input", stderr_writer, .csv_error, .{});
-    }
+    // Read all input into a buffer using block reads instead of byte-by-byte takeByte()
+    const buf = reader.allocRemaining(allocator, .unlimited) catch |err| switch (err) {
+        error.OutOfMemory => fatal("out of memory reading JSON input", stderr_writer, .csv_error, .{}),
+        error.ReadFailed => fatal("failed to read JSON input", stderr_writer, .csv_error, .{}),
+        error.StreamTooLong => unreachable, // .unlimited never triggers this
+    };
+    defer allocator.free(buf);
 
-    if (buf.items.len == 0) fatal("empty input", stderr_writer, .csv_error, .{});
+    if (buf.len == 0) fatal("empty input", stderr_writer, .csv_error, .{});
 
-    var parsed = std.json.parseFromSlice(std.json.Value, allocator, buf.items, .{}) catch
+    var parsed = std.json.parseFromSlice(std.json.Value, allocator, buf, .{}) catch
         fatal("failed to parse JSON input", stderr_writer, .csv_error, .{});
     defer parsed.deinit();
 

--- a/src/xml.zig
+++ b/src/xml.zig
@@ -694,18 +694,15 @@ pub fn getXmlColumnNames(
     xml_row: ?[]const u8,
     stderr_writer: *std.Io.Writer,
 ) [][]const u8 {
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(allocator);
-    while (true) {
-        const byte = reader.takeByte() catch |err| switch (err) {
-            error.EndOfStream => break,
-            error.ReadFailed => fatal("failed to read XML input", stderr_writer, .csv_error, .{}),
-        };
-        buf.append(allocator, byte) catch fatal("out of memory reading XML", stderr_writer, .csv_error, .{});
-    }
-    if (buf.items.len == 0) fatal("empty input", stderr_writer, .csv_error, .{});
+    const buf = reader.allocRemaining(allocator, .unlimited) catch |err| switch (err) {
+        error.OutOfMemory => fatal("out of memory reading XML", stderr_writer, .csv_error, .{}),
+        error.ReadFailed => fatal("failed to read XML input", stderr_writer, .csv_error, .{}),
+        error.StreamTooLong => unreachable, // .unlimited never triggers this
+    };
+    defer allocator.free(buf);
+    if (buf.len == 0) fatal("empty input", stderr_writer, .csv_error, .{});
 
-    var p = XmlParser.init(buf.items);
+    var p = XmlParser.init(buf);
     p.skipPrologue(stderr_writer);
     const root_name: []const u8 = if (xml_root) |r| blk: {
         p.navigateToRoot(r, stderr_writer);
@@ -758,18 +755,15 @@ pub fn summarizeXml(
     xml_row: ?[]const u8,
     stderr_writer: *std.Io.Writer,
 ) XmlSummary {
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(allocator);
-    while (true) {
-        const byte = reader.takeByte() catch |err| switch (err) {
-            error.EndOfStream => break,
-            error.ReadFailed => fatal("failed to read XML input", stderr_writer, .csv_error, .{}),
-        };
-        buf.append(allocator, byte) catch fatal("out of memory reading XML", stderr_writer, .csv_error, .{});
-    }
-    if (buf.items.len == 0) fatal("empty input", stderr_writer, .csv_error, .{});
+    const buf = reader.allocRemaining(allocator, .unlimited) catch |err| switch (err) {
+        error.OutOfMemory => fatal("out of memory reading XML", stderr_writer, .csv_error, .{}),
+        error.ReadFailed => fatal("failed to read XML input", stderr_writer, .csv_error, .{}),
+        error.StreamTooLong => unreachable, // .unlimited never triggers this
+    };
+    defer allocator.free(buf);
+    if (buf.len == 0) fatal("empty input", stderr_writer, .csv_error, .{});
 
-    var p = XmlParser.init(buf.items);
+    var p = XmlParser.init(buf);
     p.skipPrologue(stderr_writer);
     const root_name: []const u8 = if (xml_root) |r| blk: {
         p.navigateToRoot(r, stderr_writer);
@@ -831,18 +825,15 @@ pub fn loadXmlInput(
     max_rows: ?usize,
     stderr_writer: *std.Io.Writer,
 ) usize {
-    var buf: std.ArrayList(u8) = .empty;
-    defer buf.deinit(allocator);
-    while (true) {
-        const byte = reader.takeByte() catch |err| switch (err) {
-            error.EndOfStream => break,
-            error.ReadFailed => fatal("failed to read XML input", stderr_writer, .csv_error, .{}),
-        };
-        buf.append(allocator, byte) catch fatal("out of memory reading XML input", stderr_writer, .csv_error, .{});
-    }
-    if (buf.items.len == 0) fatal("empty input", stderr_writer, .csv_error, .{});
+    const buf = reader.allocRemaining(allocator, .unlimited) catch |err| switch (err) {
+        error.OutOfMemory => fatal("out of memory reading XML input", stderr_writer, .csv_error, .{}),
+        error.ReadFailed => fatal("failed to read XML input", stderr_writer, .csv_error, .{}),
+        error.StreamTooLong => unreachable, // .unlimited never triggers this
+    };
+    defer allocator.free(buf);
+    if (buf.len == 0) fatal("empty input", stderr_writer, .csv_error, .{});
 
-    var p = XmlParser.init(buf.items);
+    var p = XmlParser.init(buf);
     p.skipPrologue(stderr_writer);
     const root_name: []const u8 = if (xml_root) |r| blk: {
         p.navigateToRoot(r, stderr_writer);


### PR DESCRIPTION
## Summary

- Replaces `takeByte()` loops that read stdin one byte at a time with `reader.allocRemaining(allocator, .unlimited)`, which issues a single bulk read through the Io vtable
- For a 10 MB input this reduces reader dispatch iterations from ~10 M to a handful of 4 KB-sized reads
- No API changes; all existing integration and unit tests pass

## Functions updated

- `src/xml.zig`: `loadXmlInput`, `getXmlColumnNames`, `summarizeXml`
- `src/json.zig`: `loadJsonArray`

## Note on `readLine` in json.zig

The `readLine` function (NDJSON line reader) uses `takeByte()` for a different purpose — reading until `\n` — and is intentionally left unchanged, as it cannot be replaced with `allocRemaining`.

Closes #135