### PR TITLE
docs: add XML file usage examples to usage, man page, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,19 @@ $ printf 'name,age\nAlice,30\nBob,25' | sql-pipe -O xml 'SELECT * FROM t'
 $ cat data.xml | sql-pipe -I xml 'SELECT name FROM t WHERE age > 25'
 ```
 
+Real-world XML documents (RSS feeds, API responses) nest rows inside a container element. Use `--xml-root` to navigate to the row container and `--xml-row` to filter by element tag:
+
+```sh
+# Query an RSS feed: channel/item → rows
+$ curl -s https://feeds.feedburner.com/TheHackersNews \
+    | sql-pipe -I xml --xml-root channel --xml-row item \
+      'SELECT title FROM t LIMIT 5'
+
+# Query XML with a custom root and row name
+$ cat events.xml | sql-pipe -I xml --xml-root events --xml-row event \
+    'SELECT name, date FROM t WHERE type = "conference"'
+```
+
 Chain queries by piping back in — useful for two-pass aggregations. Pass `-H` to the first call so the second one sees column names:
 
 ```sh

--- a/docs/sql-pipe.1.scd
+++ b/docs/sql-pipe.1.scd
@@ -183,6 +183,16 @@ EXAMPLES
 
 		$ cat data.xml | sql-pipe -I xml 'SELECT name FROM t WHERE age > 25'
 
+	Query XML input with nested structure using --xml-root and --xml-row (e.g. RSS feeds):
+
+		$ curl -s https://feeds.example.com/news.rss \
+		    | sql-pipe -I xml --xml-root channel --xml-row item 'SELECT title FROM t LIMIT 5'
+
+	Output results as XML with custom element names:
+
+		$ cat data.csv \
+		    | sql-pipe -O xml --xml-root feed --xml-row entry 'SELECT * FROM t'
+
 	Preview schema and first 3 rows of a CSV file:
 
 		$ cat sales.csv | sql-pipe --sample 3

--- a/src/args.zig
+++ b/src/args.zig
@@ -193,6 +193,7 @@ pub fn printUsage(writer: *std.Io.Writer) !void {
         \\  cat data.csv | sql-pipe --output-format json 'SELECT * FROM t'
         \\  cat data.json | sql-pipe --input-format json 'SELECT * FROM t'
         \\  cat data.ndjson | sql-pipe -I ndjson -O ndjson 'SELECT name FROM t WHERE age > 18'
+        \\  cat data.xml | sql-pipe -I xml --xml-root channel --xml-row item "SELECT title FROM t"
         \\  cat data.csv | sql-pipe --sample 5
         \\
     );


### PR DESCRIPTION
## Summary

- Adds `--xml-root` / `--xml-row` XML input examples to all three documentation locations so users can discover the feature for nested documents like RSS feeds

## Changes

- **`src/args.zig`** (`--help` text): adds `cat data.xml | sql-pipe -I xml --xml-root channel --xml-row item "SELECT title FROM t"` to the Examples section
- **`docs/sql-pipe.1.scd`** (man page): two new EXAMPLES entries — nested XML input with `--xml-root`/`--xml-row` (RSS-style), and CSV-to-XML output with custom element names
- **`README.md`**: expands the XML section with a practical RSS-feed example showing when and how to use `--xml-root` and `--xml-row`

Closes #144